### PR TITLE
Fix rtd for defining parameters as timeseries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Here is a template for new release sections
 ### Removed
 
 ### Fixed
+- RTD entry for defining parameters as timeseries (#597)
 
 ## [0.5.0] - 2020-10-05
 

--- a/docs/files_to_be_displayed/example_scalar_as_timeseries_energyConversion.csv
+++ b/docs/files_to_be_displayed/example_scalar_as_timeseries_energyConversion.csv
@@ -2,7 +2,7 @@
 age_installed,year,0
 development_costs,currency,0
 specific_costs,currency/kW,7000
-efficiency,factor,"\"{'file_name': 'cops_eers_test.csv', 'header': 'no_unit', 'unit': ''}\""
+efficiency,factor,"{'file_name': 'cops_eers_test.csv', 'header': 'no_unit', 'unit': 'NA'}"
 inflow_direction,str,Electricity
 installedCap,kW,0
 label,str,Heat pump

--- a/docs/simulating_with_the_mvs.rst
+++ b/docs/simulating_with_the_mvs.rst
@@ -164,7 +164,7 @@ energy prices (currently only hourly resolution), or the state of charge
 You can define a scalar as a time series in the csv input files (not applicable for `energyConsumption.csv`),
 by replacing the scalar value with following dictionary:
 
-    {'value': {'file_name': 'your_file_name.csv', 'header': 'your_header'}, 'unit': 'your_unit'}
+    {'file_name': 'your_file_name.csv', 'header': 'your_header', 'unit': 'your_unit'}
 
 The feature was tested for following parameters:
 
@@ -183,14 +183,14 @@ You can see an implemented example here, where the heat pump has a time-dependen
    :widths: 70, 30, 50
    :header-rows: 1
 
-The benchmark test in `tests/benchmark_test_inputs/AFG_grid_heatpump_heat` (:TestACElectricityBus.test_benchmark_AFG_grid_heatpump_heat:) provides a complete set of input data for adding a time series for a parameter (`energy_price `in this case).
-
-The features were integrated with `Pull Request #63 <https://github.com/rl-institut/mvs_eland/pull/63>`_.
-For more information, you might also reference following issues:
-
-- Parameters can now be a time series (eg. efficiency of a converter, electricity prices) (`Issue #37 <https://github.com/rl-institut/mvs_eland/issue/37>`_, `Issue #82 <https://github.com/rl-institut/mvs_eland/issue/82>`_)
-
 The feature is tested with benchmark test `test_benchmark_feature_parameters_as_timeseries()`.
+
+Example input files, where at least one parameter is defined as a timeseries, be found here:
+
+* `First example <https://github.com/rl-institut/multi-vector-simulator/tree/dev/tests/benchmark_test_inputs/AFG_grid_heatpump_heat>`_: Defines the `energy_price` (`file <https://github.com/rl-institut/multi-vector-simulator/blob/dev/tests/benchmark_test_inputs/AFG_grid_heatpump_heat/csv_elements/energyProviders.csv>`_) of an energy provider as a time series
+
+* `Second example <https://github.com/rl-institut/multi-vector-simulator/tree/dev/tests/benchmark_test_inputs/Feature_parameters_as_timeseries>`_: Defines the `energy_price` (`file <https://github.com/rl-institut/multi-vector-simulator/blob/dev/tests/benchmark_test_inputs/Feature_parameters_as_timeseries/csv_elements/energyProviders.csv>`_) of an energy provider and the efficiency of a diesel generator (`file <https://github.com/rl-institut/multi-vector-simulator/blob/dev/tests/benchmark_test_inputs/Feature_parameters_as_timeseries/csv_elements/energyConversion.csv>`_) as a time series.
+
 
 Using multiple in- or output busses
 ###################################

--- a/docs/simulating_with_the_mvs.rst
+++ b/docs/simulating_with_the_mvs.rst
@@ -185,7 +185,7 @@ You can see an implemented example here, where the heat pump has a time-dependen
 
 The feature is tested with benchmark test `test_benchmark_feature_parameters_as_timeseries()`.
 
-Example input files, where at least one parameter is defined as a timeseries, be found here:
+Example input files, where at least one parameter is defined as a time series, can be found here:
 
 * `First example <https://github.com/rl-institut/multi-vector-simulator/tree/dev/tests/benchmark_test_inputs/AFG_grid_heatpump_heat>`_: Defines the `energy_price` (`file <https://github.com/rl-institut/multi-vector-simulator/blob/dev/tests/benchmark_test_inputs/AFG_grid_heatpump_heat/csv_elements/energyProviders.csv>`_) of an energy provider as a time series
 


### PR DESCRIPTION
Fix #595 

**Changes proposed in this pull request**:
- RTD entry for defining parameters as timeseries

The following steps were realized, as well (if applies):
:x: Use in-line comments to explain your code
:x: Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
:x: For new functionalities: Explain in readthedocs
:x:  Write test(s) for your new patch of code (pytests, assertion debug messages)
:x: Update the CHANGELOG.md
:x:  Apply black (`black . --exclude docs/`)
:x:  Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
