### PR TITLE
Finalize packaging mvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ mvs_csv_config.json
 /report/*.pdf
 
 # Local input folders, eg. for pilots
+/src/multi_vector_simulator/package_data/
 /example_1/
 /UVTgv_input_files/
 /inputs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Here is a template for new release sections
 - Remove REPORT_PATH constant (#607)
 - Add report assets and example simulation to package_data in `setup.py` (#607)
 - Add a util function `copy_report_assets` to copy report asset to simulation output folder when user generates the report (#607)
-- Add entrypoints for `mvs_tool` and `mvs_report` in ´setup.py´ (this can be simply typed directly in terminal) (#607)
+- Add entrypoints for `mvs_tool` and `mvs_report` in `setup.py` (this can be simply typed directly in terminal) (#607)
 - Updated readthedocs: Validation plan - Implemented tests and possible future ones (#593)
 - Updated readthedocs: Gather the MVS parameters in a csv file and parse it to a sphinx RTD file (#620)
 - Added more energy carriers and their weights to the list of already available energy carriers in constants.py (#621)
@@ -55,6 +55,9 @@ Here is a template for new release sections
 - Create mapping between EPA and MVS parameter names (#625)
 - Create parameter parser from EPA to MVS (#625)
 - Create parameter parser from MVS to EPA (#625)
+- Create function `utils.copy_inputs_template` to copy input_template from package data_files (#608)
+- Create `MANIFEST.in` file (#608)
+- Add entrypoint for `mvs_create_input_template` in `setup.py` (#608)
 
 ### Changed
 - Order of readthedocs content (#590)
@@ -86,6 +89,7 @@ Here is a template for new release sections
 ### Removed
 - Parameter label from input csv files; label is now set by filenames (for `project_data`, `economic_data`, `simulation_settings`) and column headers (for `energyConsumption`, `energyConversion`, `energyProduction`, `energyProviders`), special for storage: `filename` + `column header` (#602)
 - Remove reference to git branch ID in the report (#607)
+- Variable `TEMPLATE_INPUT_PATH` (#608)
 
 ### Fixed
 - RTD entry for defining parameters as timeseries (#597)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,19 @@ Here is a template for new release sections
 ## [Unreleased]
 
 ### Added
--
+- Create function `utils.copy_inputs_template` to copy input_template from package data_files (#608)
+- Create `MANIFEST.in` file (#608)
+- Add entrypoint for `mvs_create_input_template` in `setup.py` (#608)
+- Create script `prepare_package.py` to add data to package and build dist folder (#608)
 
 ### Changed
 - Moved `get_nested_value`, `set_nested_value`, `split_nested_path` from `tests/test_sensitivity.py` to `src/multi_vector_simulator/utils/__init__.py` (#650)
+- Rename PACKAGE_PATH to PACKAGE_DATA_PATH (#608)
+- Update release protocol within `Contributing.md` (#608)
 
 ### Removed
--
+- Variable `TEMPLATE_INPUT_PATH` (#608)
+- Field `data_files` from `setup.py` (#608)
 
 ### Fixed
 -
@@ -55,10 +61,6 @@ Here is a template for new release sections
 - Create mapping between EPA and MVS parameter names (#625)
 - Create parameter parser from EPA to MVS (#625)
 - Create parameter parser from MVS to EPA (#625)
-- Create function `utils.copy_inputs_template` to copy input_template from package data_files (#608)
-- Create `MANIFEST.in` file (#608)
-- Add entrypoint for `mvs_create_input_template` in `setup.py` (#608)
-- Create script `prepare_package.py` to add data to package and build dist folder (#608)
 
 ### Changed
 - Order of readthedocs content (#590)
@@ -86,14 +88,10 @@ Here is a template for new release sections
 - Remove unused `dict_values` argument of function `receive_timeseries_from_csv` (#625)
 - Move the end of the function `receive_timeseries_from_csv` into `C0.compute_timeseries_properties()` (#625)
 - Fix rendering issues with the PDF report and web app: Tables, ES graph sizing (#643)
-- Rename PACKAGE_PATH to PACKAGE_DATA_PATH (#608)
-- Update release protocol within `Contributing.md` (#608)
 
 ### Removed
 - Parameter label from input csv files; label is now set by filenames (for `project_data`, `economic_data`, `simulation_settings`) and column headers (for `energyConsumption`, `energyConversion`, `energyProduction`, `energyProviders`), special for storage: `filename` + `column header` (#602)
 - Remove reference to git branch ID in the report (#607)
-- Variable `TEMPLATE_INPUT_PATH` (#608)
-- Field `data_files` from `setup.py` (#608)
 
 ### Fixed
 - RTD entry for defining parameters as timeseries (#597)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Here is a template for new release sections
 - Create function `utils.copy_inputs_template` to copy input_template from package data_files (#608)
 - Create `MANIFEST.in` file (#608)
 - Add entrypoint for `mvs_create_input_template` in `setup.py` (#608)
+- Create script `prepare_package.py` to add data to package and build dist folder (#608)
 
 ### Changed
 - Order of readthedocs content (#590)
@@ -85,11 +86,14 @@ Here is a template for new release sections
 - Remove unused `dict_values` argument of function `receive_timeseries_from_csv` (#625)
 - Move the end of the function `receive_timeseries_from_csv` into `C0.compute_timeseries_properties()` (#625)
 - Fix rendering issues with the PDF report and web app: Tables, ES graph sizing (#643)
+- Rename PACKAGE_PATH to PACKAGE_DATA_PATH (#608)
+- Update release protocol within `Contributing.md` (#608)
 
 ### Removed
 - Parameter label from input csv files; label is now set by filenames (for `project_data`, `economic_data`, `simulation_settings`) and column headers (for `energyConsumption`, `energyConversion`, `energyProduction`, `energyProviders`), special for storage: `filename` + `column header` (#602)
 - Remove reference to git branch ID in the report (#607)
 - Variable `TEMPLATE_INPUT_PATH` (#608)
+- Field `data_files` from `setup.py` (#608)
 
 ### Fixed
 - RTD entry for defining parameters as timeseries (#597)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,26 +136,29 @@ Please choose `master` as target and use `vX.Y.Z` as tag version. In the descrip
 For help look into the [github release description](https://help.github.com/en/github/administering-a-repository/creating-releases).
 
 ### The actual release
+*Note*: the point 4 to 7 can be done automatically by running `python prepare_package.py`, they are displayed here explicitly for transparency
+
 1. Open a working python3 virtual environment and make sure you have the latest versions of setuptools and wheel installed:
-`python3 -m pip install --upgrade setuptools wheel twine`
-2. Delete `build/` and `dist/` directories (from previous release) to avoid errors.
-3. Make sure you pulled the release on `master` branch from `origin`: `git checkout master`, `git pull origin`
-4. Change the version without committing with release candidates (add `rc1` to the `version_num`, for example `vX.Y.Zrc1`) before the actual release, as a release with a specific version number can only be uploaded once on pypi.
-5. Rebuild the `build/` and `dist/` directories `python3 setup.py sdist bdist_wheel`
+`python3 -m pip install --upgrade setuptools wheel twine`.
+2. Make sure you pulled the release on `master` branch from `origin`: `git checkout master`, `git pull origin`.
+3. Change the version without committing with release candidates (add `rc1` to the `version_num`, for example `vX.Y.Zrc1`) before the actual release, as a release with a specific version number can only be uploaded once on pypi.
+4. Delete `build/`, `dist/` and `multi_vector_simulator.egg-info` directories (from previous release) to avoid errors.
+5. Rebuild the `build/`, `dist/` and and `multi_vector_simulator.egg-info` directories `python3 setup.py sdist bdist_wheel`
 6. Check the package with twine: `python3 -m twine check dist/*` If errors occur, fix them before the release or postpone.
-7. If everything works as expected you can now upload the package release candidate to pypi.org
+7. Copy the content of `input_template` into `src/multi-vector-simulator/package_data/input_template`, `report/asset` into `src/multi-vector-simulator/package_data/assets` and `tests/inputs` into `src/multi-vector-simulator/package_data/inputs`.
+8. If everything works as expected you can now upload the package release candidate to pypi.org
     1. Check the credentials of our pypi@rl-institut.de account on https://pypi.org.
     2. Type `twine upload dist/*`
     3. Enter `__token__` for username and your pypi token for password.
-8. Test your package:
+9. Test your package:
     1. Test the upload on test.pypi.org
         ` twine upload --repository testpypi dist/*`
     2. Test the installation: `pip install multi-vector-simulator==X.Y.Zrci`, where you replace `X.Y.Zrci` by your current version and release candidate 
     3. Then open a terminal
         `mvs_tool -f -o test_pypi`
-9. If you notice errors in the uploaded package, fix them and bump up `rc1` to `rc2` and repeat steps 2. to 9. until you don't see any more mistakes.
-10. If your release candidate works well you can now do the actual release: repeat step 2. to 9. and remove `rci` from [`src/multi-vector-simulator/version.py`](https://github.com/rl-institut/multi-vector-simulator/blob/dev/src/multi_vector_simulator/version.py).
-11. Congratulations, you just updated the package on pypi.org, you deserve a treat!
+10. If you notice errors in the uploaded package, fix them and bump up `rc1` to `rc2` and repeat steps 3. to 10. until you don't see any more mistakes.
+11. If your release candidate works well you can now do the actual release: repeat step 3. to 10. and remove `rci` from [`src/multi-vector-simulator/version.py`](https://github.com/rl-institut/multi-vector-simulator/blob/dev/src/multi_vector_simulator/version.py).
+12. Congratulations, you just updated the package on pypi.org, you deserve a treat!
 
 ### After the release
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+graft  input_template
+graft  tests/inputs
+graft  report

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,1 @@
-graft  input_template
-graft  tests/inputs
-graft  report
+graft src/multi_vector_simulator/package_data

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -1,3 +1,5 @@
+.. _installation-steps:
+
 ========================
 Getting started with MVS
 ========================

--- a/docs/simulating_with_the_mvs.rst
+++ b/docs/simulating_with_the_mvs.rst
@@ -48,6 +48,12 @@ For that, each of the following files have to be present in the folder "csv_elem
 
 For easy set-up of your energy system, we have provided an empty input folder template as well
 `here <https://github.com/rl-institut/multi-vector-simulator/blob/dev/input_template>`_.
+
+You can conveniently create a copy of this folder in your local path with the command (after having followed :ref:`the installation steps<installation-steps>`)
+.. code::
+
+    mvs_create_input_template
+
 A simple example system is setup with this `input folder <https://github.com/rl-institut/multi-vector-simulator/blob/dev/tests/inputs>`_.
 When defining your energy system with this CSV files,
 please also refer to the definition of parameters that you can find here: `stable <https://mvs-eland.readthedocs.io/en/stable/MVS_parameters.html>`_ / `latest <https://mvs-eland.readthedocs.io/en/latest/MVS_parameters.html>`_.

--- a/prepare_package.py
+++ b/prepare_package.py
@@ -1,0 +1,25 @@
+import shutil
+import os
+
+# Remove the files built by `python setup.py sdist bdist_wheel`
+for dist_file in ("dist", "build", "src/multi_vector_simulator.egg-info"):
+    shutil.rmtree(dist_file, ignore_errors=True)
+
+# Delete the previous package_data folder
+pkg_data_folder = os.path.join("src", "multi_vector_simulator", "package_data")
+shutil.rmtree(pkg_data_folder, ignore_errors=True)
+
+# Reconstitute the package_data folder
+for pgk_data_src, pkg_data_dest in zip(
+    ("report/assets", "tests/inputs", "input_template"),
+    ("assets", "inputs", "input_template"),
+):
+    shutil.copytree(
+        os.path.join(".", pgk_data_src), os.path.join(pkg_data_folder, pkg_data_dest)
+    )
+
+# Rebuild the package
+os.system("python setup.py sdist bdist_wheel")
+
+# Check the package
+os.system("twine check dist/*")

--- a/setup.py
+++ b/setup.py
@@ -189,6 +189,15 @@ setup(
                 if fn.endswith(".csv")
             ],
         ),
+        (
+            "input_template/csv_elements",
+            [
+                path.join("input_template", "csv_elements", fn)
+                for fn in listdir("input_template/csv_elements")
+                if fn.endswith(".csv")
+            ],
+        ),
+        ("input_template/time_series", ["input_template/time_series/blank"]),
     ],  # Optional
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow

--- a/setup.py
+++ b/setup.py
@@ -138,8 +138,7 @@ setup(
     # called `my_module.py` to exist:
     #
     #   py_modules=["my_module"],
-    #
-    packages=["multi_vector_simulator", "multi_vector_simulator.utils"],  # Required
+    packages=["multi_vector_simulator", "multi_vector_simulator.utils",],  # Required
     # Specify which Python versions you support. In contrast to the
     # 'Programming Language' classifiers above, 'pip install' will check this
     # and refuse to install the project if the version does not match. If you
@@ -167,6 +166,7 @@ setup(
     #
     # If using Python 2.6 or earlier, then these have to be included in
     # MANIFEST.in as well.
+    include_package_data=True,
     # package_data={  # Optional
     #     'sample': ['package_data.dat'],
     # },
@@ -175,30 +175,7 @@ setup(
     # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files
     #
     # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-    data_files=[
-        (
-            "assets",
-            ["report/assets/logo-eland-original.jpg", "report/assets/styles.css"],
-        ),
-        ("inputs", ["tests/inputs/mvs_config.json"]),
-        (
-            "inputs/time_series",
-            [
-                path.join("tests", "inputs", "time_series", fn)
-                for fn in listdir("tests/inputs/time_series")
-                if fn.endswith(".csv")
-            ],
-        ),
-        (
-            "input_template/csv_elements",
-            [
-                path.join("input_template", "csv_elements", fn)
-                for fn in listdir("input_template/csv_elements")
-                if fn.endswith(".csv")
-            ],
-        ),
-        ("input_template/time_series", ["input_template/time_series/blank"]),
-    ],  # Optional
+    # data_files=[],  # Optional
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # `pip` to create the appropriate form of executable for the target

--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,7 @@ setup(
         "console_scripts": [
             "mvs_tool=multi_vector_simulator.cli:main",
             "mvs_report=multi_vector_simulator.cli:report",
+            "mvs_create_input_template=multi_vector_simulator.cli:create_input_template_folder",
         ],
     },
     # List additional URLs that are relevant to your project as a dict.

--- a/src/multi_vector_simulator/A0_initialization.py
+++ b/src/multi_vector_simulator/A0_initialization.py
@@ -443,6 +443,9 @@ def process_user_arguments(
         and os.path.exists(os.path.join(path_input_folder, JSON_FNAME)) is False
     ):
         path_input_folder = os.path.join(PACKAGE_DATA_PATH, INPUT_FOLDER)
+        logging.info(
+            "No default input file found in your path, using example simulation input"
+        )
 
     path_input_file = check_input_folder(path_input_folder, input_type)
     check_output_folder(path_input_folder, path_output_folder, overwrite)

--- a/src/multi_vector_simulator/A0_initialization.py
+++ b/src/multi_vector_simulator/A0_initialization.py
@@ -59,7 +59,7 @@ from oemof.tools import logger
 
 from multi_vector_simulator.utils.constants import (
     REPO_PATH,
-    PACKAGE_PATH,
+    PACKAGE_DATA_PATH,
     DEFAULT_INPUT_PATH,
     DEFAULT_OUTPUT_PATH,
     JSON_FNAME,
@@ -442,7 +442,7 @@ def process_user_arguments(
         path_input_folder == DEFAULT_INPUT_PATH
         and os.path.exists(os.path.join(path_input_folder, JSON_FNAME)) is False
     ):
-        path_input_folder = os.path.join(PACKAGE_PATH, INPUT_FOLDER)
+        path_input_folder = os.path.join(PACKAGE_DATA_PATH, INPUT_FOLDER)
 
     path_input_file = check_input_folder(path_input_folder, input_type)
     check_output_folder(path_input_folder, path_output_folder, overwrite)

--- a/src/multi_vector_simulator/cli.py
+++ b/src/multi_vector_simulator/cli.py
@@ -37,7 +37,17 @@ import multi_vector_simulator.C0_data_processing as data_processing
 import multi_vector_simulator.D0_modelling_and_optimization as modelling
 import multi_vector_simulator.E0_evaluation as evaluation
 import multi_vector_simulator.F0_output as output_processing
-from multi_vector_simulator.F2_autoreport import create_app, open_in_browser, print_pdf
+
+try:
+    from multi_vector_simulator.F2_autoreport import (
+        create_app,
+        open_in_browser,
+        print_pdf,
+    )
+except ModuleNotFoundError:
+    logging.warning(
+        "Some packages are mising to generate automatic report, if you want to install them use \n\tpip install multi-vector-simulator[report]"
+    )
 
 from multi_vector_simulator.version import version_num, version_date
 
@@ -257,7 +267,7 @@ def create_input_template_folder():
     None, create a new folder in the current directory
     """
 
-    logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
+    logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
     copy_inputs_template(REPO_PATH)
 
 

--- a/src/multi_vector_simulator/cli.py
+++ b/src/multi_vector_simulator/cli.py
@@ -41,8 +41,10 @@ from multi_vector_simulator.F2_autoreport import create_app, open_in_browser, pr
 
 from multi_vector_simulator.version import version_num, version_date
 
+from multi_vector_simulator.utils import copy_inputs_template
 
 from multi_vector_simulator.utils.constants import (
+    REPO_PATH,
     CSV_ELEMENTS,
     CSV_EXT,
     PATH_INPUT_FILE,
@@ -243,6 +245,20 @@ def report(pdf=None, path_simulation_output_json=None, path_pdf_report=None):
                 "mvs_report.py`.\nTo let it run for a longer time, change timeout setting in "
                 "the mvs_report.py file\n" + banner
             )
+
+
+def create_input_template_folder():
+    """Create a copy of the input_template folder in the current directory
+
+    The input_template folder is located within the multi_vector_simulator package
+
+    Returns
+    -------
+    None, create a new folder in the current directory
+    """
+
+    logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
+    copy_inputs_template(REPO_PATH)
 
 
 if __name__ == "__main__":

--- a/src/multi_vector_simulator/utils/__init__.py
+++ b/src/multi_vector_simulator/utils/__init__.py
@@ -5,7 +5,7 @@ import shutil
 import logging
 import pandas as pd
 from .constants import (
-    PACKAGE_PATH,
+    PACKAGE_DATA_PATH,
     JSON_FNAME,
     CSV_ELEMENTS,
     OUTPUT_FOLDER,
@@ -304,7 +304,7 @@ def copy_report_assets(path_destination_folder):
         # copy from the default asset folder from mvs package
         try:
             assets_folder = shutil.copytree(
-                os.path.join(PACKAGE_PATH, "assets"), assets_folder
+                os.path.join(PACKAGE_DATA_PATH, "assets"), assets_folder
             )
         except FileNotFoundError:
             assets_folder = shutil.copytree(
@@ -338,7 +338,7 @@ def copy_inputs_template(path_destination_folder):
         # copy from the default asset folder from mvs package
         try:
             inputs_template_folder = shutil.copytree(
-                os.path.join(PACKAGE_PATH, TEMPLATE_INPUT_FOLDER),
+                os.path.join(PACKAGE_DATA_PATH, TEMPLATE_INPUT_FOLDER),
                 inputs_template_folder,
             )
             logging.info(

--- a/src/multi_vector_simulator/utils/__init__.py
+++ b/src/multi_vector_simulator/utils/__init__.py
@@ -15,6 +15,7 @@ from .constants import (
     JSON_FNAME,
     MISSING_PARAMETERS_KEY,
     EXTRA_PARAMETERS_KEY,
+    TEMPLATE_INPUT_FOLDER,
 )
 
 
@@ -315,3 +316,42 @@ def copy_report_assets(path_destination_folder):
             "from multi_vector_simulator's package".format(assets_folder)
         )
     return assets_folder
+
+
+def copy_inputs_template(path_destination_folder):
+    """Copy the inputs template folder
+
+    Parameters
+    ----------
+    path_destination_folder: str
+        path where the inputs template folder should be copied to
+
+    Returns
+    -------
+    Path of the destination folder
+
+    """
+    inputs_template_folder = os.path.join(
+        path_destination_folder, TEMPLATE_INPUT_FOLDER
+    )
+    if os.path.exists(inputs_template_folder) is False:
+        # copy from the default asset folder from mvs package
+        try:
+            inputs_template_folder = shutil.copytree(
+                os.path.join(PACKAGE_PATH, TEMPLATE_INPUT_FOLDER),
+                inputs_template_folder,
+            )
+            logging.info(
+                f"The following folder was successfully created into your local "
+                f"directory {inputs_template_folder}"
+            )
+        except FileNotFoundError:
+            logging.warning(
+                "If you installed the package in develop mode, then you cannot use this command"
+            )
+    else:
+        logging.warning(
+            "The inputs template folder {} exists already, it will not be replaced by default "
+            "folder from multi_vector_simulator's package".format(TEMPLATE_INPUT_FOLDER)
+        )
+    return inputs_template_folder

--- a/src/multi_vector_simulator/utils/constants.py
+++ b/src/multi_vector_simulator/utils/constants.py
@@ -47,8 +47,6 @@ ARG_PATH_SIM_OUTPUT = "output_folder"
 DEFAULT_INPUT_PATH = os.path.join(REPO_PATH, INPUT_FOLDER)
 DEFAULT_OUTPUT_PATH = os.path.join(REPO_PATH, OUTPUT_FOLDER)
 
-TEMPLATE_INPUT_PATH = os.path.join(REPO_PATH, TEMPLATE_INPUT_FOLDER)
-
 PATH_INPUT_FILE = "path_input_file"
 PATH_INPUT_FOLDER = "path_input_folder"
 PATH_OUTPUT_FOLDER = "path_output_folder"

--- a/src/multi_vector_simulator/utils/constants.py
+++ b/src/multi_vector_simulator/utils/constants.py
@@ -4,8 +4,8 @@ from multi_vector_simulator.utils.constants_json_strings import *
 
 # path to the root of this repository (assumes this file is in src/mvs_eland/utils folder)
 REPO_PATH = os.path.abspath(os.path.curdir)
-PACKAGE_PATH = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PACKAGE_DATA_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "package_data"
 )
 # name of the default input folder
 INPUT_FOLDER = "inputs"


### PR DESCRIPTION
Addresses #588, fix #614 

**Changes proposed in this pull request**:
- Add entrypoints for `mvs_tool` and `mvs_report` in `setup.py` (this can be simply typed directly in terminal)
- Create function `utils.copy_inputs_template` to copy input_template from package data_files
- Create `MANIFEST.in` file
- Add entrypoint for `mvs_create_input_template` in `setup.py`
- Create script `prepare_package.py` to add data to package and build dist folder
- Rename PACKAGE_PATH to PACKAGE_DATA_PATH
- Update release protocol within `Contributing.md`
- Remove variable `TEMPLATE_INPUT_PATH` and field `data_files` from `setup.py`

**Test locally**
- in a new environment run `pip install multi-vector-simulator==0.5.0rc13`, then make sure you are not in the mvs repo and run `mvs_tool`, it should create a folder `MVS_output`
- Delete the  folder `MVS_output`
- You can then run `pip install multi-vector-simulator==0.5.0rc13[report]` and run `mvs_tool -pdf`, this should create a folder `MVS_output` with a subfolder `report` in which the `.pdf` report is located (styling of the report is partly fixed in #643)

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)



<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
