### PR TITLE
Add log messages to results json file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Here is a template for new release sections
 - Improved the description of assigning weightage to energy carriers in readthedocs (#619)
 - Replaced the DSO sub-system image in Modelling Assumptions chapter of readthedocs (#622)
 - Fixed several typos in readthedocs (#622)
+- Move the function parse_log_messages to F0 and modify it to print log messages in results JSON file (#623)
 
 ### Removed
 - Parameter label from input csv files; label is now set by filenames (for `project_data`, `economic_data`, `simulation_settings`) and column headers (for `energyConsumption`, `energyConversion`, `energyProduction`, `energyProviders`), special for storage: `filename` + `column header` (#602)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Here is a template for new release sections
 - Updated readthedocs: Gather the MVS parameters in a csv file and parse it to a sphinx RTD file (#620)
 - Added more energy carriers and their weights to the list of already available energy carriers in constants.py (#621)
 - Three new KPI's added to MVS_output.rst read the docs page: Onsite energy fraction, Onsite energy matching, Degree of autonomy (#609)
-
+- New constant variables: `LOGS = "logs"`, `WARNINGS = "warnings"`, `ERRORS = "errors"` (#623)
 
 ### Changed
 - Order of readthedocs content (#590)
@@ -51,6 +51,7 @@ Here is a template for new release sections
 - Replaced the DSO sub-system image in Modelling Assumptions chapter of readthedocs (#622)
 - Fixed several typos in readthedocs (#622)
 - Move the function parse_log_messages to F0 and modify it to print log messages in results JSON file (#623)
+- Move the function `parse_log_messages` from F1 to F0 and modify it to print log messages in results JSON file (#623)
 
 ### Removed
 - Parameter label from input csv files; label is now set by filenames (for `project_data`, `economic_data`, `simulation_settings`) and column headers (for `energyConsumption`, `energyConversion`, `energyProduction`, `energyProviders`), special for storage: `filename` + `column header` (#602)

--- a/src/multi_vector_simulator/E0_evaluation.py
+++ b/src/multi_vector_simulator/E0_evaluation.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import oemof.solph as solph
 import pandas as pd
@@ -8,6 +9,7 @@ import multi_vector_simulator.E2_economics as E2
 import multi_vector_simulator.E3_indicator_calculation as E3
 
 import multi_vector_simulator.E4_verification as E4
+import multi_vector_simulator.F0_output as F0
 
 from multi_vector_simulator.utils.constants_json_strings import (
     UNIT,
@@ -36,6 +38,12 @@ from multi_vector_simulator.utils.constants_json_strings import (
 from multi_vector_simulator.utils.constants_output import (
     KPI_COST_MATRIX_ENTRIES,
     KPI_SCALAR_MATRIX_ENTRIES,
+)
+
+from multi_vector_simulator.utils.constants import (
+    PATH_OUTPUT_FOLDER,
+    OUTPUT_FOLDER,
+    LOGFILE,
 )
 
 r"""

--- a/src/multi_vector_simulator/E0_evaluation.py
+++ b/src/multi_vector_simulator/E0_evaluation.py
@@ -169,6 +169,12 @@ def evaluate_dict(dict_values, results_main, results_meta):
     E3.total_renewable_and_non_renewable_energy_origin(dict_values)
     E3.renewable_share(dict_values)
     # E3.add_degree_of_sector_coupling(dict_values) feature not finished
+    F0.parse_simulation_log(
+        path_log_file=os.path.join(
+            dict_values[SIMULATION_SETTINGS][PATH_OUTPUT_FOLDER], LOGFILE
+        ),
+        dict_values=dict_values,
+    )
 
     # Tests and checks
     logging.info("Running validity checks.")

--- a/src/multi_vector_simulator/E0_evaluation.py
+++ b/src/multi_vector_simulator/E0_evaluation.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 import oemof.solph as solph
 import pandas as pd
@@ -9,7 +8,6 @@ import multi_vector_simulator.E2_economics as E2
 import multi_vector_simulator.E3_indicator_calculation as E3
 
 import multi_vector_simulator.E4_verification as E4
-import multi_vector_simulator.F0_output as F0
 
 from multi_vector_simulator.utils.constants_json_strings import (
     UNIT,
@@ -40,11 +38,6 @@ from multi_vector_simulator.utils.constants_output import (
     KPI_SCALAR_MATRIX_ENTRIES,
 )
 
-from multi_vector_simulator.utils.constants import (
-    PATH_OUTPUT_FOLDER,
-    OUTPUT_FOLDER,
-    LOGFILE,
-)
 
 r"""
 Module E0 evaluation
@@ -169,12 +162,6 @@ def evaluate_dict(dict_values, results_main, results_meta):
     E3.total_renewable_and_non_renewable_energy_origin(dict_values)
     E3.renewable_share(dict_values)
     # E3.add_degree_of_sector_coupling(dict_values) feature not finished
-    F0.parse_simulation_log(
-        path_log_file=os.path.join(
-            dict_values[SIMULATION_SETTINGS][PATH_OUTPUT_FOLDER], LOGFILE
-        ),
-        dict_values=dict_values,
-    )
 
     # Tests and checks
     logging.info("Running validity checks.")

--- a/src/multi_vector_simulator/F0_output.py
+++ b/src/multi_vector_simulator/F0_output.py
@@ -76,6 +76,13 @@ def evaluate_dict(dict_values, path_pdf_report=None, path_png_figs=None):
         "Summarizing simulation results to results_timeseries and results_scalars_assets."
     )
 
+    parse_simulation_log(
+        path_log_file=os.path.join(
+            dict_values[SIMULATION_SETTINGS][PATH_OUTPUT_FOLDER], LOGFILE
+        ),
+        dict_values=dict_values,
+    )
+
     # storing all flows to exel.
     store_timeseries_all_busses_to_excel(dict_values)
 
@@ -166,7 +173,6 @@ def store_scalars_to_excel(dict_values):
                 results_scalar_output_file,
                 kpi_set,
             )
-    return
 
 
 def store_timeseries_all_busses_to_excel(dict_values):
@@ -192,7 +198,6 @@ def store_timeseries_all_busses_to_excel(dict_values):
             dict_values[OPTIMIZED_FLOWS][bus].to_excel(open_file, sheet_name=bus)
 
     logging.debug("Saved flows at busses to: %s.", timeseries_output_file)
-    return
 
 
 def parse_simulation_log(path_log_file, dict_values):
@@ -227,7 +232,6 @@ def parse_simulation_log(path_log_file, dict_values):
 
     # Loop through the list of lines of the log file to check for the relevant log messages and gather them in dicts
     for line in log_messages:
-        print(line)
         if "ERROR" in line:
             i = i + 1
             substrings = line.split(" - ")

--- a/src/multi_vector_simulator/F0_output.py
+++ b/src/multi_vector_simulator/F0_output.py
@@ -221,8 +221,8 @@ def parse_simulation_log(path_log_file, dict_values):
 
     i = j = 0
 
+    # Loop through the list of lines of the log file to check for the relevant log messages and gather them in dicts
     for line in log_messages:
-        print('++++++++++++++++++++')
         print(line)
         if "ERROR" in line:
             i = i + 1

--- a/src/multi_vector_simulator/F0_output.py
+++ b/src/multi_vector_simulator/F0_output.py
@@ -30,6 +30,10 @@ from multi_vector_simulator.utils.constants_json_strings import (
     RESOURCES,
     KPI_SCALARS_DICT,
     ECONOMIC_DATA,
+    SIMULATION_RESULTS,
+    LOGS,
+    ERRORS,
+    WARNINGS,
 )
 
 r"""
@@ -210,7 +214,7 @@ def parse_simulation_log(path_log_file, dict_values):
 
     """
     # Dictionaries to gather non-fatal warning and error messages that appear during the simulation
-    log_dict = {"ERRORS": {}, "WARNINGS": {}}
+
     error_dict, warning_dict = {}, {}
 
     if path_log_file is None:
@@ -235,11 +239,9 @@ def parse_simulation_log(path_log_file, dict_values):
             message_string = substrings[-1]
             warning_dict.update({j: message_string})
 
-    log_dict["ERRORS"] = error_dict
-    log_dict["WARNINGS"] = warning_dict
+    log_dict = {ERRORS: error_dict, WARNINGS: warning_dict}
 
-    dict_values.update(log_dict)
-    return
+    dict_values.update({SIMULATION_RESULTS: {LOGS: log_dict}})
 
 
 def store_as_json(dict_values, output_folder=None, file_name=None):

--- a/src/multi_vector_simulator/F0_output.py
+++ b/src/multi_vector_simulator/F0_output.py
@@ -19,6 +19,8 @@ except ModuleNotFoundError:
 from multi_vector_simulator.utils.constants import (
     SIMULATION_SETTINGS,
     PATH_OUTPUT_FOLDER,
+    OUTPUT_FOLDER,
+    LOGFILE,
 )
 from multi_vector_simulator.utils.constants_json_strings import (
     UNIT,

--- a/src/multi_vector_simulator/F0_output.py
+++ b/src/multi_vector_simulator/F0_output.py
@@ -208,7 +208,7 @@ def parse_simulation_log(path_log_file, dict_values):
 
     """
     # Dictionaries to gather non-fatal warning and error messages that appear during the simulation
-    log_dict = {'ERRORS': {}, 'WARNINGS': {}}
+    log_dict = {"ERRORS": {}, "WARNINGS": {}}
     error_dict, warning_dict = {}, {}
 
     if path_log_file is None:
@@ -233,8 +233,8 @@ def parse_simulation_log(path_log_file, dict_values):
             message_string = substrings[-1]
             warning_dict.update({j: message_string})
 
-    log_dict['ERRORS'] = error_dict
-    log_dict['WARNINGS'] = warning_dict
+    log_dict["ERRORS"] = error_dict
+    log_dict["WARNINGS"] = warning_dict
 
     dict_values.update(log_dict)
     return

--- a/src/multi_vector_simulator/F0_output.py
+++ b/src/multi_vector_simulator/F0_output.py
@@ -189,6 +189,57 @@ def store_timeseries_all_busses_to_excel(dict_values):
     return
 
 
+def parse_simulation_log(path_log_file, dict_values):
+    """Gather a log file with several log messages, this function gathers them all and inputs them into the dict with
+    all input and output parameters up to F0
+
+    Parameters
+    ----------
+    path_log_file: str/None
+        path to the mvs log file
+        Default: None
+
+    dict_values :
+        dict Of all input and output parameters up to F0
+
+    Returns
+    -------
+    Updates the results dictionary with the log messages of the simulation
+
+    """
+    # Dictionaries to gather non-fatal warning and error messages that appear during the simulation
+    log_dict = {'ERRORS': {}, 'WARNINGS': {}}
+    error_dict, warning_dict = {}, {}
+
+    if path_log_file is None:
+        path_log_file = os.path.join(OUTPUT_FOLDER, LOGFILE)
+
+    with open(path_log_file) as log_messages:
+        log_messages = log_messages.readlines()
+
+    i = j = 0
+
+    for line in log_messages:
+        print('++++++++++++++++++++')
+        print(line)
+        if "ERROR" in line:
+            i = i + 1
+            substrings = line.split(" - ")
+            message_string = substrings[-1]
+            error_dict.update({i: message_string})
+        elif "WARNING" in line:
+            j = j + 1
+            substrings = line.split(" - ")
+            message_string = substrings[-1]
+            warning_dict.update({j: message_string})
+
+    log_dict['ERRORS'] = error_dict
+    log_dict['WARNINGS'] = warning_dict
+
+    dict_values.update(log_dict)
+    return
+
+
 def store_as_json(dict_values, output_folder=None, file_name=None):
     """Converts dict_values to JSON format and saves dict_values as a JSON file or return json
 

--- a/src/multi_vector_simulator/F1_plotting.py
+++ b/src/multi_vector_simulator/F1_plotting.py
@@ -136,42 +136,6 @@ def extract_plot_data_and_title(dict_values, df_dem=None):
     return dict_for_plots, dict_plot_labels
 
 
-def parse_simulation_log(path_log_file=None, log_type="ERROR"):
-    """Gather the log message of a certain type in a given log file
-
-    Parameters
-    ----------
-    path_log_file: str/None
-        path to the mvs log file
-        Default: None
-    log_type: str
-        one of "ERROR" or "WARNING"
-        Default: "ERROR"
-
-    Returns
-    -------
-
-    """
-    # Dictionaries to gather non-fatal warning and error messages that appear during the simulation
-    logs_dict = {}
-
-    if path_log_file is None:
-        path_log_file = os.path.join(OUTPUT_FOLDER, LOGFILE)
-
-    with open(path_log_file) as log_messages:
-        log_messages = log_messages.readlines()
-
-    i = 0
-    for line in log_messages:
-        if log_type in line:
-            i = i + 1
-            substrings = line.split(" - ")
-            message_string = substrings[-1]
-            logs_dict.update({i: message_string})
-
-    return logs_dict
-
-
 def fixed_width_text(text, char_num=10):
     """Add linebreaks every char_num characters in a given text.
 

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -923,11 +923,11 @@ def create_app(results_json, path_sim_output=None):
                         children=[
                             insert_subsection(
                                 title="Warning Messages",
-                                content=insert_log_messages(log_dict=warnings_dict),
+                                content=insert_log_messages(log_dict=results_json['WARNINGS']),
                             ),
                             insert_subsection(
                                 title="Error Messages",
-                                content=insert_log_messages(log_dict=errors_dict),
+                                content=insert_log_messages(log_dict=results_json['ERRORS']),
                             ),
                         ]
                     ),

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -63,6 +63,7 @@ from multi_vector_simulator.utils.constants_json_strings import (
     LOGS,
     ERRORS,
     WARNINGS,
+    SIMULATION_RESULTS,
 )
 
 from multi_vector_simulator.E1_process_results import (
@@ -927,13 +928,17 @@ def create_app(results_json, path_sim_output=None):
                             insert_subsection(
                                 title="Warning Messages",
                                 content=insert_log_messages(
-                                    log_dict=results_json[LOGS][WARNINGS]
+                                    log_dict=results_json[SIMULATION_RESULTS][LOGS][
+                                        WARNINGS
+                                    ]
                                 ),
                             ),
                             insert_subsection(
                                 title="Error Messages",
                                 content=insert_log_messages(
-                                    log_dict=results_json[LOGS][ERRORS]
+                                    log_dict=results_json[SIMULATION_RESULTS][LOGS][
+                                        ERRORS
+                                    ]
                                 ),
                             ),
                         ]

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -70,7 +70,6 @@ from multi_vector_simulator.E1_process_results import (
     convert_scalars_to_dataframe,
 )
 from multi_vector_simulator.F1_plotting import (
-    parse_simulation_log,
     plot_timeseries,
     plot_piecharts_of_costs,
     plot_optimized_capacities,
@@ -675,13 +674,6 @@ def create_app(results_json, path_sim_output=None):
     df_scalar_matrix = convert_scalar_matrix_to_dataframe(results_json)
     df_cost_matrix = convert_cost_matrix_to_dataframe(results_json)
     df_kpi_scalars = convert_scalars_to_dataframe(results_json)
-
-    warnings_dict = parse_simulation_log(
-        path_log_file=os.path.join(path_sim_output, LOGFILE), log_type="WARNING",
-    )
-    errors_dict = parse_simulation_log(
-        path_log_file=os.path.join(path_sim_output, LOGFILE), log_type="ERROR",
-    )
 
     # App layout and populating it with different elements
     app.layout = html.Div(

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -60,6 +60,9 @@ from multi_vector_simulator.utils.constants_json_strings import (
     SCENARIO_ID,
     DEMANDS,
     RESOURCES,
+    LOGS,
+    ERRORS,
+    WARNINGS,
 )
 
 from multi_vector_simulator.E1_process_results import (
@@ -924,13 +927,13 @@ def create_app(results_json, path_sim_output=None):
                             insert_subsection(
                                 title="Warning Messages",
                                 content=insert_log_messages(
-                                    log_dict=results_json["WARNINGS"]
+                                    log_dict=results_json[LOGS][WARNINGS]
                                 ),
                             ),
                             insert_subsection(
                                 title="Error Messages",
                                 content=insert_log_messages(
-                                    log_dict=results_json["ERRORS"]
+                                    log_dict=results_json[LOGS][ERRORS]
                                 ),
                             ),
                         ]

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -923,11 +923,15 @@ def create_app(results_json, path_sim_output=None):
                         children=[
                             insert_subsection(
                                 title="Warning Messages",
-                                content=insert_log_messages(log_dict=results_json['WARNINGS']),
+                                content=insert_log_messages(
+                                    log_dict=results_json["WARNINGS"]
+                                ),
                             ),
                             insert_subsection(
                                 title="Error Messages",
-                                content=insert_log_messages(log_dict=results_json['ERRORS']),
+                                content=insert_log_messages(
+                                    log_dict=results_json["ERRORS"]
+                                ),
                             ),
                         ]
                     ),

--- a/src/multi_vector_simulator/utils/constants_json_strings.py
+++ b/src/multi_vector_simulator/utils/constants_json_strings.py
@@ -185,6 +185,11 @@ ASSET_DICT = "Asset_list"
 
 SIMULATION_RESULTS = "simulation_results"
 
+# Logs
+LOGS = "logs"
+ERRORS = "errors"
+WARNINGS = "warnings"
+
 # Names for KPI output
 KPI = "kpi"
 KPI_SCALARS_DICT = "scalars"


### PR DESCRIPTION
Fix #617 

**Changes proposed in this pull request**:
- Move the function to parse log messages to E0
- Modify the function to save the logging messages to the output JSON results file

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
