### PR TITLE
Fix issue with report generation in develop install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Here is a template for new release sections
 - Fixed several typos in readthedocs (#622)
 - Move the function parse_log_messages to F0 and modify it to print log messages in results JSON file (#623)
 - Move the function `parse_log_messages` from F1 to F0 and modify it to print log messages in results JSON file (#623)
+- If `assets` folder is not found in package look in current folder for `report/assets` folder (#632)
 
 ### Removed
 - Parameter label from input csv files; label is now set by filenames (for `project_data`, `economic_data`, `simulation_settings`) and column headers (for `energyConsumption`, `energyConversion`, `energyProduction`, `energyProviders`), special for storage: `filename` + `column header` (#602)

--- a/src/multi_vector_simulator/utils/__init__.py
+++ b/src/multi_vector_simulator/utils/__init__.py
@@ -190,9 +190,14 @@ def copy_report_assets(path_destination_folder):
     assets_folder = os.path.join(path_destination_folder, "report", "assets")
     if os.path.exists(assets_folder) is False:
         # copy from the default asset folder from mvs package
-        assets_folder = shutil.copytree(
-            os.path.join(PACKAGE_PATH, "assets"), assets_folder
-        )
+        try:
+            assets_folder = shutil.copytree(
+                os.path.join(PACKAGE_PATH, "assets"), assets_folder
+            )
+        except FileNotFoundError:
+            assets_folder = shutil.copytree(
+                os.path.join(".", "report", "assets"), assets_folder
+            )
     else:
         logging.warning(
             "The assets folder {} exists already, it will not be replaced by default folder "


### PR DESCRIPTION
Fix #631 

`python setup.py develop`
followed by 
`mvs_tool -i tests/inputs/ -ext csv -f -pdf` 
should work now

previously only worked via normal pip install or `python setup.py install`

**Changes proposed in this pull request**:
- If `assets` folder is not found in package look in current folder for `report/assets` folder

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [ ] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
