### PR TITLE
Fix formatting and rendering issues in the autoreport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Here is a template for new release sections
 - Replace `==` by `is` in expression with `True`, `False` or `None` (#625)
 - Remove unused `dict_values` argument of function `receive_timeseries_from_csv` (#625)
 - Move the end of the function `receive_timeseries_from_csv` into `C0.compute_timeseries_properties()` (#625)
+- Fix rendering issues with the PDF report and web app (#643)
 
 ### Removed
 - Parameter label from input csv files; label is now set by filenames (for `project_data`, `economic_data`, `simulation_settings`) and column headers (for `energyConsumption`, `energyConversion`, `energyProduction`, `energyProviders`), special for storage: `filename` + `column header` (#602)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ Here is a template for new release sections
 - Replace `==` by `is` in expression with `True`, `False` or `None` (#625)
 - Remove unused `dict_values` argument of function `receive_timeseries_from_csv` (#625)
 - Move the end of the function `receive_timeseries_from_csv` into `C0.compute_timeseries_properties()` (#625)
-- Fix rendering issues with the PDF report and web app (#643)
+- Fix rendering issues with the PDF report and web app: Tables, ES graph sizing (#643)
 
 ### Removed
 - Parameter label from input csv files; label is now set by filenames (for `project_data`, `economic_data`, `simulation_settings`) and column headers (for `energyConsumption`, `energyConversion`, `energyProduction`, `energyProviders`), special for storage: `filename` + `column header` (#602)

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -818,6 +818,7 @@ def create_app(results_json, path_sim_output=None):
                                             ENERGY_SYSTEM_GRAPH.decode()
                                         ),
                                         alt="Energy System Graph",
+                                        style={"maxWidth": "100%"},
                                     ),
                                 ],
                             ),

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -559,7 +559,7 @@ def create_app(results_json, path_sim_output=None):
         path_sim_output = results_json[SIMULATION_SETTINGS][PATH_OUTPUT_FOLDER]
 
     # create a "report" folder containing an "asset" folder
-    asset_folder = copy_report_assets(path_sim_output)
+    asset_folder = os.path.abspath(copy_report_assets(path_sim_output))
 
     # external CSS stylesheets
     external_stylesheets = [

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -88,7 +88,7 @@ CSV_FOLDER = os.path.join(REPO_PATH, OUTPUT_FOLDER, INPUTS_COPY, CSV_ELEMENTS)
 
 async def _print_pdf_from_chrome(path_pdf_report):
     r"""
-    This function generates the PDF report from the web app rendered on a Chromimum-based browser.
+    This function generates the PDF report from the web app rendered on a Chromium-based browser.
 
     Parameters
     ----------
@@ -106,7 +106,9 @@ async def _print_pdf_from_chrome(path_pdf_report):
     await page.goto(
         "http://127.0.0.1:8050", {"waitUntil": "domcontentloaded", "timeout": 120000}
     )
-    await page.waitForSelector("#main-div")
+    await page.waitForSelector(
+        ".dash-cell", {"visible": "true",},
+    )
     await page.pdf({"path": path_pdf_report, "format": "A4", "printBackground": True})
     await browser.close()
     print("*" * 10)

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -824,7 +824,7 @@ def create_app(results_json, path_sim_output=None):
                         ],
                     ),
                     insert_subsection(
-                        title="Energy demand",
+                        title="Energy Demand",
                         content=[
                             insert_body_text(
                                 "The simulation was performed for the energy system "
@@ -846,7 +846,7 @@ def create_app(results_json, path_sim_output=None):
                         ],
                     ),
                     insert_subsection(
-                        title="Energy system components",
+                        title="Energy System Components",
                         content=[
                             insert_body_text(
                                 "The energy system is comprised of "
@@ -904,7 +904,7 @@ def create_app(results_json, path_sim_output=None):
                         ],
                     ),
                     insert_subsection(
-                        title="Energy system key performance indicators",
+                        title="Energy System: Key Performance Indicators (KPIs)",
                         content=[
                             insert_body_text(
                                 f"In the following the key performance indicators of the of {projectName}, "


### PR DESCRIPTION
Fix #634 

**Changes proposed in this pull request**:
- Correct the case of headings of some sections
- Fit the ES graph within the page boundaries
- Fix the issue of dash tables not being rendered in the PDF report

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
