### PR TITLE
Move functions to manage values in nested dict to utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Here is a template for new release sections
 -
 
 ### Changed
--
+- Moved `get_nested_value`, `set_nested_value`, `split_nested_path` from `tests/test_sensitivity.py` to `src/multi_vector_simulator/utils/__init__.py` (#650)
 
 ### Removed
 -

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -4,11 +4,14 @@ In this module the tests run over whole simulation from main, not just single fu
 What should differ between the different functions is the input file
 
 """
-import copy
 import json
 import logging
 import os
-
+from multi_vector_simulator.utils import (
+    get_nested_value,
+    set_nested_value,
+    split_nested_path,
+)
 from multi_vector_simulator.server import run_simulation
 from multi_vector_simulator.B0_data_input_json import (
     load_json,
@@ -19,120 +22,10 @@ from _constants import TEST_REPO_PATH
 TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, "MVS_outputs_simulation")
 
 
-def set_nested_value(dct, value, keys):
-    r"""Set a value within a nested dict structure given the path within the dict
-
-    Parameters
-    ----------
-    dct: dict
-        the (potentially nested) dict from which we want to get a value
-    value: variable type
-        value to assign within the dict
-    keys: tuple
-        Tuple containing the succession of keys which lead to the value within the nested dict
-
-    Returns
-    -------
-    The value under the path within the (potentially nested) dict
-
-    Example
-    -------
-    >>> dct = dict(a=dict(a1=1, a2=2),b=dict(b1=dict(b11=11,b12=dict(b121=121))))
-    >>> print(set_nested_value(dct, 400,("b", "b1", "b12","b121")))
-    {'a': {'a1': 1, 'a2': 2}, 'b': {'b1': {'b11': 11, 'b12': {'b121': 400}}}}
-    """
-    if isinstance(keys, tuple) is True:
-        answer = copy.deepcopy(dct)
-        if len(keys) > 1:
-            answer[keys[0]] = set_nested_value(dct[keys[0]], value, keys[1:])
-        elif len(keys) == 1:
-            answer[keys[0]] = value
-        else:
-            raise ValueError(
-                "The tuple argument 'keys' from set_nested_value() should not be empty"
-            )
-    else:
-        raise TypeError("The argument 'keys' from set_nested_value() should be a tuple")
-    return answer
-
-
-def get_nested_value(dct, keys):
-    r"""Get a value from a succession of keys within a nested dict structure
-
-    Parameters
-    ----------
-    dct: dict
-        the (potentially nested) dict from which we want to get a value
-    keys: tuple
-        Tuple containing the succession of keys which lead to the value within the nested dict
-
-    Returns
-    -------
-    The value under the path within the (potentially nested) dict
-
-    Example
-    -------
-    >>> dct = dict(a=dict(a1=1, a2=2),b=dict(b1=dict(b11=11,b12=dict(b121=121))))
-    >>> print(get_nested_value(dct, ("b", "b1", "b12","b121")))
-    121
-    """
-    if isinstance(keys, tuple) is True:
-        if len(keys) > 1:
-            answer = get_nested_value(dct[keys[0]], keys[1:])
-        elif len(keys) == 1:
-            answer = dct[keys[0]]
-        else:
-            raise ValueError(
-                "The tuple argument 'keys' from get_nested_value() should not be empty"
-            )
-    else:
-        raise TypeError("The argument 'keys' from get_nested_value() should be a tuple")
-    return answer
-
-
-def split_nested_path(path):
-    r"""Separate a single-string path in a nested dict in a list of keys
-
-
-    Parameters
-    ----------
-    path: str or tuple
-        path within a nested dict which is expressed as a str of a succession of keys separated by
-        a `.` or a `,`. The order of keys is to be read from left to right.
-
-    Returns
-    -------
-    Tuple containing the succession of keys which lead to the value within the nested dict
-
-    """
-    SEPARATORS = (".", ",")
-    keys_list = None
-    if isinstance(path, str):
-        separator_count = 0
-        keys_separator = None
-        for separator in SEPARATORS:
-            if separator in path:
-                if path.count(separator) > 0:
-                    if separator_count > 0:
-                        raise ValueError(
-                            f"The separator of the nested dict's path is not unique"
-                        )
-                    separator_count = path.count(separator)
-                    keys_separator = separator
-        if keys_separator is not None:
-            keys_list = tuple(path.split(keys_separator))
-    elif isinstance(path, tuple):
-        keys_list = path
-    else:
-        raise TypeError("The argument path is not str type")
-
-    return tuple(keys_list)
-
-
 def single_param_variation_analysis(
     param_values, json_input, json_path_to_param_value, json_path_to_output_value=None
 ):
-    r"""Run mvs simulations by varying one of the input parameters ta access output's sensitivity
+    r"""Run mvs simulations by varying one of the input parameters to access output's sensitivity
 
     Parameters
     ----------


### PR DESCRIPTION
Fix #558

**Changes proposed in this pull request**:
- Moved `get_nested_value`, `set_nested_value`, `split_nested_path` from `tests/test_sensitivity.py` to `src/multi_vector_simulator/utils/__init__.py`

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
