### PR TITLE
Temporary fix for demands section in the autoreport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Here is a template for new release sections
 - Remove unused `dict_values` argument of function `receive_timeseries_from_csv` (#625)
 - Move the end of the function `receive_timeseries_from_csv` into `C0.compute_timeseries_properties()` (#625)
 - Fix rendering issues with the PDF report and web app: Tables, ES graph sizing (#643)
+- Improve the description of demands in the autoreport (#647)
 
 ### Removed
 - Parameter label from input csv files; label is now set by filenames (for `project_data`, `economic_data`, `simulation_settings`) and column headers (for `energyConsumption`, `energyConversion`, `energyProduction`, `energyProviders`), special for storage: `filename` + `column header` (#602)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ Here is a template for new release sections
 - Remove unused `dict_values` argument of function `receive_timeseries_from_csv` (#625)
 - Move the end of the function `receive_timeseries_from_csv` into `C0.compute_timeseries_properties()` (#625)
 - Fix rendering issues with the PDF report and web app: Tables, ES graph sizing (#643)
-- Improve the description of demands in the autoreport (#647)
+- Improve the description of demands in the autoreport: Adapted section so that it applies to all vectors (#647)
 
 ### Removed
 - Parameter label from input csv files; label is now set by filenames (for `project_data`, `economic_data`, `simulation_settings`) and column headers (for `energyConsumption`, `energyConversion`, `energyProduction`, `energyProviders`), special for storage: `filename` + `column header` (#602)

--- a/src/multi_vector_simulator/E1_process_results.py
+++ b/src/multi_vector_simulator/E1_process_results.py
@@ -593,7 +593,7 @@ def convert_demand_to_dataframe(dict_values):
             {
                 dem: [
                     demands[dem][UNIT],
-                    demands[dem]['energyVector'],
+                    demands[dem]["energyVector"],
                     demands[dem][TIMESERIES_PEAK][VALUE],
                     demands[dem][TIMESERIES_AVERAGE][VALUE],
                     demands[dem][TIMESERIES_TOTAL][VALUE],
@@ -604,7 +604,13 @@ def convert_demand_to_dataframe(dict_values):
     df_dem = pd.DataFrame.from_dict(
         demand_data,
         orient="index",
-        columns=[UNIT, "Type of Demand", "Peak Demand", "Mean Demand", "Total Annual Demand"],
+        columns=[
+            UNIT,
+            "Type of Demand",
+            "Peak Demand",
+            "Mean Demand",
+            "Total Annual Demand",
+        ],
     )
     df_dem.index.name = "Demands"
     df_dem = df_dem.reset_index()

--- a/src/multi_vector_simulator/E1_process_results.py
+++ b/src/multi_vector_simulator/E1_process_results.py
@@ -593,7 +593,7 @@ def convert_demand_to_dataframe(dict_values):
             {
                 dem: [
                     demands[dem][UNIT],
-                    demands[dem]["energyVector"],
+                    demands[dem][ENERGY_VECTOR],
                     demands[dem][TIMESERIES_PEAK][VALUE],
                     demands[dem][TIMESERIES_AVERAGE][VALUE],
                     demands[dem][TIMESERIES_TOTAL][VALUE],

--- a/src/multi_vector_simulator/E1_process_results.py
+++ b/src/multi_vector_simulator/E1_process_results.py
@@ -593,6 +593,7 @@ def convert_demand_to_dataframe(dict_values):
             {
                 dem: [
                     demands[dem][UNIT],
+                    demands[dem]['energyVector'],
                     demands[dem][TIMESERIES_PEAK][VALUE],
                     demands[dem][TIMESERIES_AVERAGE][VALUE],
                     demands[dem][TIMESERIES_TOTAL][VALUE],
@@ -603,7 +604,7 @@ def convert_demand_to_dataframe(dict_values):
     df_dem = pd.DataFrame.from_dict(
         demand_data,
         orient="index",
-        columns=[UNIT, "Peak Demand", "Mean Demand", "Total Demand per annum"],
+        columns=[UNIT, "Type of Demand", "Peak Demand", "Mean Demand", "Total Annual Demand"],
     )
     df_dem.index.name = "Demands"
     df_dem = df_dem.reset_index()

--- a/src/multi_vector_simulator/E1_process_results.py
+++ b/src/multi_vector_simulator/E1_process_results.py
@@ -582,7 +582,7 @@ def convert_demand_to_dataframe(dict_values):
         elif DSO_FEEDIN in column_label:
             drop_list.append(column_label)
 
-    # Remove some elements from drop_list (ie. sinks that are not demands) from data
+    # Remove some elements from drop_list (ie. sinks that are not demands) from the dict holding demand data
     for item in drop_list:
         del demands[item]
 

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -834,9 +834,9 @@ def create_app(results_json, path_sim_output=None):
                                 "covering the following sectors: "
                             ),
                             insert_body_text(f"{sec_list}"),
-                            html.H4("Electricity Demand"),
+                            html.H4("List of Demands"),
                             insert_body_text(
-                                "Electricity demands " "that have to be supplied are:"
+                                "Demands that have to be supplied are:"
                             ),
                             make_dash_data_table(df_dem),
                             html.Div(

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -835,9 +835,7 @@ def create_app(results_json, path_sim_output=None):
                             ),
                             insert_body_text(f"{sec_list}"),
                             html.H4("List of Demands"),
-                            insert_body_text(
-                                "Demands that have to be supplied are:"
-                            ),
+                            insert_body_text("Demands that have to be supplied are:"),
                             make_dash_data_table(df_dem),
                             html.Div(
                                 children=ready_timeseries_plots(results_json, DEMANDS)


### PR DESCRIPTION
Partly addresses #535 

**Changes proposed in this pull request**:
- Reformat the way content is displayed in the demands section of the autoreport

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
