### PR TITLE
Warn for missing parameters when converting from EPA to MVS format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ Here is a template for new release sections
 ## [Unreleased]
 
 ### Added
--
+- Warning for missing parameter when parsing inputs from epa to mvs (#656)
 ### Changed
--
+- Function `utils.compare_input_parameters_with_reference` accepts parameters as dict for json comparison (#656)
 ### Removed
 -
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ Here is a template for new release sections
 
 ### Added
 - Warning for missing parameter when parsing inputs from epa to mvs (#656)
+- New module `exceptions.py` in `multi_vector_simulator.utils` to gather custom MVS exceptions (#656)
 ### Changed
 - Function `utils.compare_input_parameters_with_reference` accepts parameters as dict for json comparison (#656)
+- Move A1 and C0 custom exceptions into `multi_vector_simulator.utils.exceptions.py` (#656)
 ### Removed
 -
 ### Fixed

--- a/src/multi_vector_simulator/A1_csv_to_json.py
+++ b/src/multi_vector_simulator/A1_csv_to_json.py
@@ -75,42 +75,19 @@ from multi_vector_simulator.utils.constants_json_strings import (
     SOC_MIN,
     STORAGE_CAPACITY,
     FILENAME,
-)
-from multi_vector_simulator.utils.constants_json_strings import (
     UNIT,
     VALUE,
     ENERGY_STORAGE,
 )
 
 
-class MissingParameterError(ValueError):
-    """Exception raised for missing parameters of a csv input file."""
-
-    pass
-
-
-class MissingParameterWarning(UserWarning):
-    """Exception raised for missing new parameters of a csv input file, which will be set to default."""
-
-    pass
-
-
-class WrongParameterWarning(UserWarning):
-    """Exception raised for errors in the parameters of a csv input file."""
-
-    pass
-
-
-class CsvParsingError(ValueError):
-    """Exception raised for errors in the parameters of a csv input file."""
-
-    pass
-
-
-class WrongStorageColumn(ValueError):
-    """Exception raised for wrong column name in "storage_xx" input file."""
-
-    pass
+from multi_vector_simulator.utils.exceptions import (
+    MissingParameterError,
+    MissingParameterWarning,
+    WrongParameterWarning,
+    CsvParsingError,
+    WrongStorageColumn,
+)
 
 
 def create_input_json(

--- a/src/multi_vector_simulator/C0_data_processing.py
+++ b/src/multi_vector_simulator/C0_data_processing.py
@@ -16,6 +16,10 @@ from multi_vector_simulator.utils.constants import (
 )
 
 from multi_vector_simulator.utils.constants_json_strings import *
+from multi_vector_simulator.utils.exceptions import (
+    InvalidPeakDemandPricingPeriodsError,
+    UnknownEnergyCarrierError,
+)
 import multi_vector_simulator.B0_data_input_json as B0
 import multi_vector_simulator.C1_verification as C1
 import multi_vector_simulator.C2_economic_functions as C2
@@ -40,16 +44,6 @@ Module C0 prepares the data read from csv or json for simulation, ie. pre-proces
 - Define all necessary energyBusses and add all assets that are connected to them specifically with asset name and label
 - Multiply `maximumCap` of non-dispatchable sources by max(timeseries(kWh/kWp)) as the `maximumCap` is limiting the flow but we want to limit the installed capacity (see issue #446)
 """
-
-
-class InvalidPeakDemandPricingPeriods(ValueError):
-    # Exeption if an input is not valid
-    pass
-
-
-class UnknownEnergyCarrier(ValueError):
-    # Exception if an energy carrier is not in DEFAULT_WEIGHTS_ENERGY_CARRIERS
-    pass
 
 
 def all(dict_values):
@@ -162,7 +156,7 @@ def check_if_energy_carrier_is_defined_in_DEFAULT_WEIGHTS_ENERGY_CARRIERS(
     - test_check_if_energy_carrier_is_defined_in_DEFAULT_WEIGHTS_ENERGY_CARRIERS_fails()
     """
     if energy_carrier not in DEFAULT_WEIGHTS_ENERGY_CARRIERS:
-        raise UnknownEnergyCarrier(
+        raise UnknownEnergyCarrierError(
             f"The energy carrier {energy_carrier} of asset group {asset_group}, asset {asset} is unknown, "
             f"as it is not defined within the DEFAULT_WEIGHTS_ENERGY_CARRIERS."
             f"Please check the energy carrier, or update the DEFAULT_WEIGHTS_ENERGY_CARRIERS in contants.py (dev)."
@@ -909,7 +903,7 @@ def determine_months_in_a_peak_demand_pricing_period(
                 f"an possibly unexpected number of periods will be considered."
             )
     if number_of_pricing_periods not in [1, 2, 3, 4, 6, 12]:
-        raise InvalidPeakDemandPricingPeriods(
+        raise InvalidPeakDemandPricingPeriodsError(
             f"You have defined a number of peak demand pricing periods of {number_of_pricing_periods}. "
             f"Acceptable values are, however: 1 (yearly), 2 (half-yearly), 3 (each trimester), 4 (quarterly), 6 (every two months) and 1 (monthly)."
         )

--- a/src/multi_vector_simulator/E3_indicator_calculation.py
+++ b/src/multi_vector_simulator/E3_indicator_calculation.py
@@ -778,8 +778,9 @@ def equation_onsite_energy_fraction(total_generation, total_feedin):
     else:
         # TODO find a better way to deal with this
         onsite_energy_fraction = 0
-        logging.warning("The total local energy generation is zero, therefore the onsite energy fraction cannot be calculated and is set to 0")
-
+        logging.warning(
+            "The total local energy generation is zero, therefore the onsite energy fraction cannot be calculated and is set to 0"
+        )
 
     return onsite_energy_fraction
 

--- a/src/multi_vector_simulator/F0_output.py
+++ b/src/multi_vector_simulator/F0_output.py
@@ -283,14 +283,18 @@ def store_as_json(dict_values, output_folder=None, file_name=None):
     )
     if file_name is not None:
         file_path = os.path.abspath(os.path.join(output_folder, file_name + ".json"))
-        myfile = open(file_path, "w")
 
-        myfile.write(json_data)
-        myfile.close()
-        logging.info(
-            "Converted and stored processed simulation data to json: %s", file_path
-        )
-        answer = file_path
+        if os.path.exists(os.path.dirname(file_path)):
+            myfile = open(file_path, "w")
+
+            myfile.write(json_data)
+            myfile.close()
+            logging.info(
+                "Converted and stored processed simulation data to json: %s", file_path
+            )
+            answer = file_path
+        else:
+            answer = None
     else:
         answer = json_data
 

--- a/src/multi_vector_simulator/utils/__init__.py
+++ b/src/multi_vector_simulator/utils/__init__.py
@@ -109,10 +109,16 @@ def compare_input_parameters_with_reference(folder_path, ext=JSON_EXT):
     under the key {EXTRA_PARAMETERS_KEY}
     """
     if ext == JSON_EXT:
-        # load the mvs input json file into a dict
-        json_file_path = os.path.join(folder_path, JSON_FNAME)
-        with open(json_file_path) as fp:
-            main_parameters = json.load(fp)
+
+        if isinstance(folder_path, dict):
+            # the folder_path argument is already a dict
+            main_parameters = folder_path
+        else:
+            # load the mvs input json file into a dict
+            json_file_path = os.path.join(folder_path, JSON_FNAME)
+            with open(json_file_path) as fp:
+                main_parameters = json.load(fp)
+
     elif ext == CSV_EXT:
         # list the mvs input csv files
         folder_csv_path = os.path.join(folder_path, CSV_ELEMENTS)

--- a/src/multi_vector_simulator/utils/data_parser.py
+++ b/src/multi_vector_simulator/utils/data_parser.py
@@ -103,7 +103,7 @@ EPA_PARAM_KEYS = {
     SIMULATION_SETTINGS: [START_DATE, EVALUATED_PERIOD, TIMESTEP],
     CONSTRAINTS: [],
     KPI: [KPI_SCALARS_DICT],
-    FIX_COST: []
+    FIX_COST: [],
 }
 
 # Fields expected for assets' parameters of json returned to EPA
@@ -223,7 +223,13 @@ def convert_epa_params_to_mvs(epa_dict):
 
     dict_values = {}
 
-    for param_group in [PROJECT_DATA, ECONOMIC_DATA, SIMULATION_SETTINGS, CONSTRAINTS, FIX_COST]:
+    for param_group in [
+        PROJECT_DATA,
+        ECONOMIC_DATA,
+        SIMULATION_SETTINGS,
+        CONSTRAINTS,
+        FIX_COST,
+    ]:
 
         if MAP_MVS_EPA[param_group] in epa_dict:
 

--- a/src/multi_vector_simulator/utils/data_parser.py
+++ b/src/multi_vector_simulator/utils/data_parser.py
@@ -11,6 +11,10 @@ This module defines all functions to convert formats between EPA and MVS
 import pprint
 import logging
 
+from multi_vector_simulator.utils import compare_input_parameters_with_reference
+
+
+from multi_vector_simulator.utils.constants import MISSING_PARAMETERS_KEY
 from multi_vector_simulator.utils.constants_json_strings import (
     PROJECT_DATA,
     ECONOMIC_DATA,
@@ -64,6 +68,8 @@ from multi_vector_simulator.utils.constants_json_strings import (
     KPI_SCALARS_DICT,
     DATA,
 )
+
+from multi_vector_simulator.A1_csv_to_json import MissingParameterError
 
 pp = pprint.PrettyPrinter(indent=4)
 
@@ -264,6 +270,28 @@ def convert_epa_params_to_mvs(epa_dict):
             logging.warning(
                 f"The parameters {MAP_MVS_EPA[asset_group]} are not present in the parameters to be parsed into mvs json format"
             )
+
+    comparison = compare_input_parameters_with_reference(dict_values)
+
+    if MISSING_PARAMETERS_KEY in comparison:
+        errror_msg = []
+
+        d = comparison[MISSING_PARAMETERS_KEY]
+
+        errror_msg.append(" ")
+        errror_msg.append(" ")
+        errror_msg.append(
+            "The following parameter groups and sub parameters are missing from input parameters:"
+        )
+
+        for asset_group in d.keys():
+            errror_msg.append(asset_group)
+            print(asset_group)
+            if d[asset_group] is not None:
+                for k in d[asset_group]:
+                    errror_msg.append(f"\t`{k}` parameter")
+
+        raise (MissingParameterError("\n".join(errror_msg)))
 
     return dict_values
 

--- a/src/multi_vector_simulator/utils/data_parser.py
+++ b/src/multi_vector_simulator/utils/data_parser.py
@@ -70,7 +70,7 @@ from multi_vector_simulator.utils.constants_json_strings import (
     DATA,
 )
 
-from multi_vector_simulator.A1_csv_to_json import MissingParameterError
+from multi_vector_simulator.utils.exceptions import MissingParameterError
 
 pp = pprint.PrettyPrinter(indent=4)
 

--- a/src/multi_vector_simulator/utils/data_parser.py
+++ b/src/multi_vector_simulator/utils/data_parser.py
@@ -66,6 +66,7 @@ from multi_vector_simulator.utils.constants_json_strings import (
     TIMESTEP,
     KPI,
     KPI_SCALARS_DICT,
+    FIX_COST,
     DATA,
 )
 
@@ -91,6 +92,7 @@ MAP_EPA_MVS = {
     "constraints": CONSTRAINTS,
     "renewable_asset": RENEWABLE_ASSET_BOOL,
     KPI: KPI,
+    FIX_COST: FIX_COST,
 }
 
 MAP_MVS_EPA = {value: key for (key, value) in MAP_EPA_MVS.items()}
@@ -101,6 +103,7 @@ EPA_PARAM_KEYS = {
     SIMULATION_SETTINGS: [START_DATE, EVALUATED_PERIOD, TIMESTEP],
     CONSTRAINTS: [],
     KPI: [KPI_SCALARS_DICT],
+    FIX_COST: []
 }
 
 # Fields expected for assets' parameters of json returned to EPA
@@ -220,7 +223,7 @@ def convert_epa_params_to_mvs(epa_dict):
 
     dict_values = {}
 
-    for param_group in [PROJECT_DATA, ECONOMIC_DATA, SIMULATION_SETTINGS, CONSTRAINTS]:
+    for param_group in [PROJECT_DATA, ECONOMIC_DATA, SIMULATION_SETTINGS, CONSTRAINTS, FIX_COST]:
 
         if MAP_MVS_EPA[param_group] in epa_dict:
 

--- a/src/multi_vector_simulator/utils/exceptions.py
+++ b/src/multi_vector_simulator/utils/exceptions.py
@@ -1,0 +1,29 @@
+class MissingParameterError(ValueError):
+    """Exception raised for missing parameters of a csv input file."""
+
+    pass
+
+
+class MissingParameterWarning(UserWarning):
+    """Exception raised for missing new parameters of a csv input file, which will be set to default."""
+
+    pass
+
+
+class WrongParameterWarning(UserWarning):
+    """Exception raised for errors in the parameters of a csv input file."""
+
+    pass
+
+
+class CsvParsingError(ValueError):
+    """Exception raised for errors in the parameters of a csv input file."""
+
+    pass
+
+
+class WrongStorageColumn(ValueError):
+    """Exception raised for wrong column name in "storage_xx" input file."""
+
+    pass
+

--- a/src/multi_vector_simulator/utils/exceptions.py
+++ b/src/multi_vector_simulator/utils/exceptions.py
@@ -27,3 +27,12 @@ class WrongStorageColumn(ValueError):
 
     pass
 
+
+class InvalidPeakDemandPricingPeriodsError(ValueError):
+    # Exeption if an input is not valid
+    pass
+
+
+class UnknownEnergyCarrierError(ValueError):
+    # Exception if an energy carrier is not in DEFAULT_WEIGHTS_ENERGY_CARRIERS
+    pass

--- a/tests/test_A1_csv_to_json.py
+++ b/tests/test_A1_csv_to_json.py
@@ -7,6 +7,13 @@ import numpy as np
 import multi_vector_simulator.A1_csv_to_json as A1
 import multi_vector_simulator.B0_data_input_json as data_input
 
+from multi_vector_simulator.utils.exceptions import (
+    MissingParameterError,
+    MissingParameterWarning,
+    WrongParameterWarning,
+    CsvParsingError,
+    WrongStorageColumn,
+)
 from multi_vector_simulator.utils.constants import (
     WARNING_TEXT,
     REQUIRED_IN_CSV_ELEMENTS,
@@ -94,7 +101,7 @@ def test_if_check_for_official_extra_parameters_adds_no_parameter_when_not_neces
 
 
 def test_if_check_for_official_extra_parameters_raises_warning_if_parameter_doesnt_exist():
-    with pytest.warns(A1.MissingParameterWarning):
+    with pytest.warns(MissingParameterWarning):
         parameters_updated, _ = A1.check_for_official_extra_parameters(
             filename_a,
             df_no_new_parameter,
@@ -172,7 +179,7 @@ def test_create_json_from_csv_with_ampersand_separated_csv():
 
 def test_create_json_from_csv_with_unknown_separator_for_csv_raises_CsvParsingError():
 
-    with pytest.raises(A1.CsvParsingError):
+    with pytest.raises(CsvParsingError):
         A1.create_json_from_csv(
             DUMMY_CSV_PATH,
             "csv_unknown_separator",
@@ -183,15 +190,15 @@ def test_create_json_from_csv_with_unknown_separator_for_csv_raises_CsvParsingEr
 
 def test_create_json_from_csv_without_providing_parameters_raises_MissingParameterError():
 
-    with pytest.raises(A1.MissingParameterError):
+    with pytest.raises(MissingParameterError):
         A1.create_json_from_csv(
             DUMMY_CSV_PATH, "csv_comma", parameters=[], asset_is_a_storage=False
         )
 
 
-def test_create_json_from_csv_with_uncomplete_parameters_raises_WrongParameterWarning():
+def test_create_json_from_csv_with_uncomplete_parameters_raises_MissingParameterError():
 
-    with pytest.raises(A1.MissingParameterError):
+    with pytest.raises(MissingParameterError):
         A1.create_json_from_csv(
             DUMMY_CSV_PATH,
             "csv_comma",
@@ -202,7 +209,7 @@ def test_create_json_from_csv_with_uncomplete_parameters_raises_WrongParameterWa
 
 def test_create_json_from_csv_with_wrong_parameters_raises_WrongParameterWarning():
 
-    with pytest.warns(A1.WrongParameterWarning):
+    with pytest.warns(WrongParameterWarning):
         A1.create_json_from_csv(
             DUMMY_CSV_PATH,
             "csv_wrong_parameter",
@@ -271,7 +278,7 @@ def test_conversion():
 
 def test_create_json_from_csv_storage_raises_WrongParameterWarning():
 
-    with pytest.warns(A1.WrongParameterWarning):
+    with pytest.warns(WrongParameterWarning):
         A1.create_json_from_csv(
             DUMMY_CSV_PATH,
             "csv_storage_wrong_parameter",
@@ -282,7 +289,7 @@ def test_create_json_from_csv_storage_raises_WrongParameterWarning():
 
 def test_create_json_from_csv_storage_raises_MissingParameterError():
 
-    with pytest.raises(A1.MissingParameterError):
+    with pytest.raises(MissingParameterError):
         A1.create_json_from_csv(
             DUMMY_CSV_PATH,
             "csv_storage_wrong_parameter",
@@ -302,7 +309,7 @@ def test_create_json_from_csv_storage_raises_MissingParameterError():
 
 def test_create_json_from_csv_storage_raises_WrongParameterWarning_for_wrong_values():
 
-    with pytest.warns(A1.WrongParameterWarning):
+    with pytest.warns(WrongParameterWarning):
         A1.create_json_from_csv(
             DUMMY_CSV_PATH,
             "csv_storage_wrong_values",

--- a/tests/test_C0_data_processing.py
+++ b/tests/test_C0_data_processing.py
@@ -56,6 +56,10 @@ from multi_vector_simulator.utils.constants_json_strings import (
     ENERGY_VECTOR,
     ASSET_DICT,
 )
+from multi_vector_simulator.utils.exceptions import (
+    InvalidPeakDemandPricingPeriodsError,
+    UnknownEnergyCarrierError,
+)
 
 
 def test_add_economic_parameters():
@@ -386,10 +390,10 @@ def test_apply_function_to_single_or_list_apply_to_list():
 
 
 def test_determine_months_in_a_peak_demand_pricing_period_not_valid():
-    with pytest.raises(C0.InvalidPeakDemandPricingPeriods):
+    with pytest.raises(InvalidPeakDemandPricingPeriodsError):
         C0.determine_months_in_a_peak_demand_pricing_period(
             5, 365
-        ), f"No C0.InvalidPeakDemandPricingPeriods is raised eventhough an invalid number of pricing periods is requested."
+        ), f"No InvalidPeakDemandPricingPeriodsError is raised eventhough an invalid number of pricing periods is requested."
 
 
 def test_determine_months_in_a_peak_demand_pricing_period_valid():
@@ -462,7 +466,7 @@ def test_check_if_energy_carrier_is_defined_in_DEFAULT_WEIGHTS_ENERGY_CARRIERS_p
 
 
 def test_check_if_energy_carrier_is_defined_in_DEFAULT_WEIGHTS_ENERGY_CARRIERS_fail():
-    with pytest.raises(C0.UnknownEnergyCarrier):
+    with pytest.raises(UnknownEnergyCarrierError):
         C0.check_if_energy_carrier_is_defined_in_DEFAULT_WEIGHTS_ENERGY_CARRIERS(
             "Bio-Diesel", "asset_group", "asset"
         ), f"The energy carrier `Bio-Diesel` is recognized in the `DEFAULT_WEIGHTS_ENERGY_CARRIERS`, eventhough it should not be defined."


### PR DESCRIPTION
**Changes proposed in this pull request**:
- Warning for missing parameter when parsing inputs from epa to mvs
- New module `exceptions.py` in `multi_vector_simulator.utils` to gather custom MVS exceptions (#656)
- Move A1 and C0 custom exceptions into `multi_vector_simulator.utils.exceptions.py` (#656)

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
