### PR TITLE
Modify autoreport to display demands sector-wise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,12 @@ Here is a template for new release sections
 ### Added
 - Warning for missing parameter when parsing inputs from epa to mvs (#656)
 - New module `exceptions.py` in `multi_vector_simulator.utils` to gather custom MVS exceptions (#656)
+- New argument for functions `E1.convert_demand_to_dataframe`, `F1.plot_timeseries`, `F2.ready_timeseries_plots` (#665)
 ### Changed
 - Function `utils.compare_input_parameters_with_reference` accepts parameters as dict for json comparison (#656)
 - Move A1 and C0 custom exceptions into `multi_vector_simulator.utils.exceptions.py` (#656)
+- Adapt `E1.convert_demand_to_dataframe` for multiple sectors (#656)
+- Improve the demands section of the autoreport: Divide the demand tables and plots sector-wise (#665)
 ### Removed
 -
 ### Fixed

--- a/src/multi_vector_simulator/E1_process_results.py
+++ b/src/multi_vector_simulator/E1_process_results.py
@@ -554,13 +554,17 @@ def add_info_flows(settings, dict_asset, flow):
     )
 
 
-def convert_demand_to_dataframe(dict_values):
+def convert_demand_to_dataframe(dict_values, sector_demands=None):
     """Dataframe used for the demands table of the report
 
     Parameters
     ----------
     dict_values: dict
         output values of MVS
+
+    sector_demands: str
+        Name of the sector of the energy system whose demands must be returned as a df by this function
+        Default: None
 
     Returns
     -------

--- a/src/multi_vector_simulator/E1_process_results.py
+++ b/src/multi_vector_simulator/E1_process_results.py
@@ -9,7 +9,7 @@ Module E1 processes the oemof results.
 
 """
 import logging
-
+import copy
 import pandas as pd
 
 from multi_vector_simulator.utils.constants import TYPE_NONE
@@ -573,7 +573,7 @@ def convert_demand_to_dataframe(dict_values, sector_demands=None):
     """
 
     # Make a dict which is a sub-dict of the JSON results file with only the consumption components of the energy system
-    demands = dict(dict_values[ENERGY_CONSUMPTION])
+    demands = copy.deepcopy(dict_values[ENERGY_CONSUMPTION])
 
     # The following block removes all the non-current sectoral demands from the demands dict
     if sector_demands is not None:

--- a/src/multi_vector_simulator/E1_process_results.py
+++ b/src/multi_vector_simulator/E1_process_results.py
@@ -571,11 +571,25 @@ def convert_demand_to_dataframe(dict_values, sector_demands=None):
     :class:`pandas.DataFrame<frame>`
 
     """
-    # Creating a dataframe for the demands
-    demands = dict_values[ENERGY_CONSUMPTION]
 
-    # Removing all columns that are not actually from demands
+    # Make a dict which is a sub-dict of the JSON results file with only the consumption components of the energy system
+    demands = dict(dict_values[ENERGY_CONSUMPTION])
+
+    # The following block removes all the non-current sectoral demands from the demands dict
+    if sector_demands is not None:
+        non_sec_demands = []
+        # Loop through the demands checking if there are keys which do not belong to the current sector
+        for demand_key in demands.keys():
+            if demands[demand_key][ENERGY_VECTOR] != (sector_demands.title()):
+                non_sec_demands.append(demand_key)
+        # Drop the non-sectoral demands from the demands dict
+        for demand_to_drop in non_sec_demands:
+            del demands[demand_to_drop]
+
+    # Removing all the keys that do not represent actual demands
     drop_list = []
+
+    # Loop though the demands identifying irrelevant demands
     for column_label in demands:
         # Identifies excess sink in demands for removal
         if EXCESS in column_label:
@@ -586,12 +600,14 @@ def convert_demand_to_dataframe(dict_values, sector_demands=None):
         elif DSO_FEEDIN in column_label:
             drop_list.append(column_label)
 
-    # Remove some elements from drop_list (ie. sinks that are not demands) from the dict holding demand data
+    # Remove some elements from drop_list (ie. sinks that are not demands) from data
     for item in drop_list:
         del demands[item]
 
+    # Create empty dict to hold the current-sector demands' data
     demand_data = {}
 
+    # Populate the above dict with data for each of the demand in the current sector
     for dem in list(demands.keys()):
         demand_data.update(
             {
@@ -604,7 +620,7 @@ def convert_demand_to_dataframe(dict_values, sector_demands=None):
                 ]
             }
         )
-
+    # Creating a dataframe with all of the demands from the above dict
     df_dem = pd.DataFrame.from_dict(
         demand_data,
         orient="index",
@@ -616,6 +632,8 @@ def convert_demand_to_dataframe(dict_values, sector_demands=None):
             "Total Annual Demand",
         ],
     )
+
+    # Operations on the index of the dataframe created above
     df_dem.index.name = "Demands"
     df_dem = df_dem.reset_index()
     df_dem = df_dem.round(2)

--- a/src/multi_vector_simulator/F1_plotting.py
+++ b/src/multi_vector_simulator/F1_plotting.py
@@ -78,6 +78,7 @@ def convert_plot_data_to_dataframe(plot_data_dict, data_type):
     df: pandas:`pandas.DataFrame<frame>`,
         timeseries for plotting
     """
+
     # Later, this dataframe can be passed to a function directly make the graphs with Plotly
     df = pd.DataFrame.from_dict(plot_data_dict[data_type], orient="columns")
 
@@ -577,8 +578,9 @@ def plot_timeseries(
     sector_demands: str
         Name of the sector of the energy system
         Default: None
+
     max_days: int
-        maximal number of days the timeserie should be displayed for
+        maximal number of days the timeseries should be displayed for
 
     color_list: list of str or list to tuple (hexadecimal or rbg code)
         list of colors

--- a/src/multi_vector_simulator/F1_plotting.py
+++ b/src/multi_vector_simulator/F1_plotting.py
@@ -556,7 +556,12 @@ def create_plotly_line_fig(
 
 
 def plot_timeseries(
-    dict_values, data_type=DEMANDS, max_days=None, color_list=None, file_path=None
+    dict_values,
+    data_type=DEMANDS,
+    sector_demands=None,
+    max_days=None,
+    color_list=None,
+    file_path=None,
 ):
     r"""Plot timeseries as line chart.
 
@@ -569,6 +574,9 @@ def plot_timeseries(
         one of DEMANDS or RESOURCES
         Default: DEMANDS
 
+    sector_demands: str
+        Name of the sector of the energy system
+        Default: None
     max_days: int
         maximal number of days the timeserie should be displayed for
 
@@ -585,7 +593,9 @@ def plot_timeseries(
     Dict with html DOM id for the figure as key and :class:`plotly.graph_objs.Figure` as value
     """
 
-    df_dem = convert_demand_to_dataframe(dict_values)
+    df_dem = convert_demand_to_dataframe(
+        dict_values=dict_values, sector_demands=sector_demands
+    )
     dict_for_plots, dict_plot_labels = extract_plot_data_and_title(
         dict_values, df_dem=df_dem
     )

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -541,6 +541,68 @@ def encode_image_file(img_path):
     return encoded_img
 
 
+def create_demands_section(output_JSON_file, sectors=None):
+    """This function creates a HTML Div element that holds an entire section with either the demands or the resources
+
+    Parameters
+    ----------
+
+    output_JSON_file: dict
+        Dict with all simulation parameters
+
+    sectors: list
+        List holding the names of sectors of the energy system as strings
+        Default: None
+
+    Returns
+    -------
+    Function call to insert_subsection() that generates the demands section of the autoreport
+
+    """
+
+    # Format the list of sectors
+    sec_list = """"""
+    for sec in sectors:
+        sec_list += "\n" + f"\u2022 {sec.upper()}"
+
+    # List of content
+    content_of_section = [
+        insert_body_text(
+            "The simulation was performed for the energy system "
+            "covering the following sectors: "
+        ),
+        insert_body_text(f"{sec_list}"),
+    ]
+
+    # Loop to generate the sector headings, sectoral-demands' tables and plots of the demands in each of the sectors
+    for sector in sectors:
+
+        # Determining the sector heading
+        sector_heading = sector.title() + " Demands"
+
+        # Collect the sector_specific demands in a dataframe
+        df_sector_demands = convert_demand_to_dataframe(
+            dict_values=output_JSON_file, sector_demands=sector
+        )
+
+        # Function call that generates a dash table from the above dataframe and saves it in a variable
+        table_with_dash = make_dash_data_table(df_sector_demands)
+
+        # Function that plots the sector-specific demands
+        sector_demand_plots = html.Div(
+            children=ready_timeseries_plots(
+                dict_values=output_JSON_file, sector_demands=sector
+            )
+        )
+
+        # Add the heading, table and plot(s) to the content list
+        content_of_section.extend(
+            (html.H4(sector_heading), table_with_dash, sector_demand_plots)
+        )
+
+    return insert_subsection(title="Energy Demands", content=content_of_section)
+
+
 # Styling of the report
 def create_app(results_json, path_sim_output=None):
     r"""Initializes the app and calls all the other functions, resulting in the web app as well as pdf.
@@ -681,7 +743,6 @@ def create_app(results_json, path_sim_output=None):
     for sec in sectors:
         sec_list += "\n" + f"\u2022 {sec.upper()}"
 
-    df_dem = convert_demand_to_dataframe(results_json)
     df_comp = convert_components_to_dataframe(results_json)
     df_scalar_matrix = convert_scalar_matrix_to_dataframe(results_json)
     df_cost_matrix = convert_cost_matrix_to_dataframe(results_json)
@@ -832,25 +893,16 @@ def create_app(results_json, path_sim_output=None):
                             ),
                         ],
                     ),
+                    html.Div(
+                        children=create_demands_section(
+                            output_JSON_file=results_json, sectors=sectors
+                        )
+                    ),
                     insert_subsection(
-                        title="Energy Demand",
-                        content=[
-                            insert_body_text(
-                                "The simulation was performed for the energy system "
-                                "covering the following sectors: "
-                            ),
-                            insert_body_text(f"{sec_list}"),
-                            html.H4("List of Demands"),
-                            insert_body_text("Demands that have to be supplied are:"),
-                            make_dash_data_table(df_dem),
-                            html.Div(
-                                children=ready_timeseries_plots(results_json, DEMANDS)
-                            ),
-                            html.H4("Resources"),
-                            html.Div(
-                                children=ready_timeseries_plots(results_json, RESOURCES)
-                            ),
-                        ],
+                        title="Resources",
+                        content=ready_timeseries_plots(
+                            results_json, data_type=RESOURCES
+                        ),
                     ),
                     insert_subsection(
                         title="Energy System Components",

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -400,7 +400,9 @@ def insert_plotly_figure(
     return html.Div(children=rendered_plots)
 
 
-def ready_timeseries_plots(dict_values, data_type=DEMANDS, only_print=False):
+def ready_timeseries_plots(
+    dict_values, data_type=DEMANDS, only_print=False, sector_demands=None
+):
     r"""Insert the timeseries line plots in a dash html layout.
 
     Parameters
@@ -417,13 +419,17 @@ def ready_timeseries_plots(dict_values, data_type=DEMANDS, only_print=False):
         but not the web app version of the auto-report.
         Default: False
 
+    sector_demands: str
+        Name of the sector of the energy system
+        Default: None
+
     Returns
     -------
     plots: list
         List containing the timeseries line plots dash components
     """
 
-    figs = plot_timeseries(dict_values, data_type)
+    figs = plot_timeseries(dict_values, data_type, sector_demands=sector_demands)
     plots = [
         insert_plotly_figure(fig, id_plot=comp_id, print_only=only_print)
         for comp_id, fig in figs.items()


### PR DESCRIPTION
Fix #535 

The two commands I used to run the simulations and generate the reports:

`mvs_tool -i tests/inputs -ext csv -f -pdf`

`mvs_tool -i tests/benchmark_test_inputs/AFG_grid_heatpump_heat -ext csv -f -pdf`

**Changes proposed in this pull request**:
- Divide the demands section of the autoreport sector-wise

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
