### PR TITLE
Add information regarding the MVS server API to the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Here is a template for new release sections
 
 ### Added
 - Updated release protocol with info on credentials for test.pypi.org (step 9) and added "Fixed" to unreleased section of changelog.md in release protocol (#695)
+- Added information about the API to the docs (#701)
 
 ### Changed 
 -

--- a/docs/Overview.rst
+++ b/docs/Overview.rst
@@ -56,3 +56,12 @@ The validation techniques used are listed here below and expanded in :ref:`valid
 
 * Comparison to other model
 
+
+Access MVS Server API
+---------------------
+
+The multi-vector simulator can be used to simulate energy systems directly via the browser using the API of the server which processes the simulation. Users can interact with the API at this `URL <https://mvs-eland.rl-institut.de/>`_.
+It is as simple as uploading the simulation files (by clicking the 'Browse' button) and then hitting the 'Run simulation' button. One can also visualize the log messages (error/warning) during the simulation.
+
+The code for the implementation of the MVS E-Land API is hosted in this `github repository <https://github.com/rl-institut/mvs_eland_api>`_.
+

--- a/docs/Overview.rst
+++ b/docs/Overview.rst
@@ -63,4 +63,4 @@ Access MVS Server API
 The Multi-Vector Simulator can be used to simulate energy systems via the browser using the `API on the RLI server <https://mvs-eland.rl-institut.de/>`__. It processes the parsed JSON input file, and returns the JSON result file.
 It is as simple as uploading the simulation files (by clicking the 'Browse' button) and then hitting the 'Run simulation' button. One can also visualize the log messages (error/warning) during the simulation.
 
-The code for the implementation of the MVS E-Land API is hosted in this `github repository <https://github.com/rl-institut/mvs_eland_api>`_.
+The code for the implementation of the MVS E-Land API is hosted in this `github repository <https://github.com/rl-institut/mvs_eland_api>`__.

--- a/docs/Overview.rst
+++ b/docs/Overview.rst
@@ -60,8 +60,7 @@ The validation techniques used are listed here below and expanded in :ref:`valid
 Access MVS Server API
 ---------------------
 
-The multi-vector simulator can be used to simulate energy systems directly via the browser using the API of the server which processes the simulation. Users can interact with the API at this `URL <https://mvs-eland.rl-institut.de/>`_.
+The Multi-Vector Simulator can be used to simulate energy systems via the browser using the `API on the RLI server <https://mvs-eland.rl-institut.de/>`__. It processes the parsed JSON input file, and returns the JSON result file.
 It is as simple as uploading the simulation files (by clicking the 'Browse' button) and then hitting the 'Run simulation' button. One can also visualize the log messages (error/warning) during the simulation.
 
 The code for the implementation of the MVS E-Land API is hosted in this `github repository <https://github.com/rl-institut/mvs_eland_api>`_.
-

--- a/docs/Overview.rst
+++ b/docs/Overview.rst
@@ -61,6 +61,6 @@ Access MVS Server API
 ---------------------
 
 The Multi-Vector Simulator can be used to simulate energy systems via the browser using the `API on the RLI server <https://mvs-eland.rl-institut.de/>`__. It processes the parsed JSON input file, and returns the JSON result file.
-It is as simple as uploading the simulation files (by clicking the 'Browse' button) and then hitting the 'Run simulation' button. One can also visualize the log messages (error/warning) during the simulation.
+The simulation is executed by uploading the simulation files (by clicking the 'Browse' button) and then hitting the 'Run simulation' button. One can also visualize the log messages (error/warning) during the simulation.
 
 The code for the implementation of the MVS E-Land API is hosted in this `github repository <https://github.com/rl-institut/mvs_eland_api>`__.


### PR DESCRIPTION
Fix #640 

**Changes proposed in this pull request**:
- Update readthedocs with information about the MVS server API and how to use it

The following steps were realized, as well (if applies):
:x: Use in-line comments to explain your code
:x: Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
:x: Apply black (`black . --exclude docs/`)
:x: Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)
:x: Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] For new functionalities: Explain in readthedocs
- [x] Update the CHANGELOG.md



*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
