### PR TITLE
Add parser description in RTD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,11 @@ Here is a template for new release sections
 - Added information about the API to the docs (#701)
 
 ### Changed 
--
+- Benchmark test for investment model (`Test_Economic_KPI.test_benchmark_Economic_KPI_C2_E2`): Expand test to LCOE as well as all all other system-wide economic parameters, transpose `test_data_economic_expected_values.csv`, change `test_data_economic_expected_values.xls` (#613)
+- Adapt pre-processing for investment benchmark tests into a seperate function (#613)
+- `COST_REPLACEMENT` is now a parameter that is included in output cost matrix (#613)
+- Improved `Code.rst` for RTD code documentation (#)
+- All `.py` files to add a module description for RTD on top (#)
 
 ### Removed
 -
@@ -35,6 +39,7 @@ Here is a template for new release sections
 - Decreased warnings of RTD compilation drastically (#693)
 - Use current version number as defined in `version.py` for RTD (#693)
 - Added storage to the table in autoreport listing the energy system components (#686)
+- Add assertion `sum(attributed_costs)==cost_total` (for single-vector system) (#613)
 
 ## [0.5.3] - 2020-12-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ Here is a template for new release sections
 - Benchmark test for investment model (`Test_Economic_KPI.test_benchmark_Economic_KPI_C2_E2`): Expand test to LCOE as well as all all other system-wide economic parameters, transpose `test_data_economic_expected_values.csv`, change `test_data_economic_expected_values.xls` (#613)
 - Adapt pre-processing for investment benchmark tests into a seperate function (#613)
 - `COST_REPLACEMENT` is now a parameter that is included in output cost matrix (#613)
-- Improved `Code.rst` for RTD code documentation (#)
-- All `.py` files to add a module description for RTD on top (#)
+- Improved `Code.rst` for RTD code documentation (#704)
+- All `.py` files to add a module description for RTD on top (#704)
 
 ### Removed
 -

--- a/docs/Code.rst
+++ b/docs/Code.rst
@@ -2,16 +2,19 @@
 Code documentation
 ==================
 
-Initialization
+Util functions
 --------------
 
-.. automodule:: multi_vector_simulator.utils.constants
+.. automodule:: multi_vector_simulator.utils.data_parser
    :members:
    :undoc-members:
 
-.. automodule:: multi_vector_simulator.utils.constants_json_strings
+.. automodule:: multi_vector_simulator.utils.helpers
    :members:
    :undoc-members:
+
+Initialization
+--------------
 
 .. automodule:: multi_vector_simulator.A0_initialization
    :members:
@@ -28,8 +31,8 @@ Data input
    :members:
    :undoc-members:
 
-Data processing
----------------
+Data pre-processing and validity checks
+---------------------------------------
 
 .. automodule:: multi_vector_simulator.C0_data_processing
    :members:
@@ -43,8 +46,8 @@ Data processing
    :members:
    :undoc-members:
 
-Modelling
----------
+Building the energy system model
+--------------------------------
 
 .. automodule:: multi_vector_simulator.D0_modelling_and_optimization
    :members:
@@ -58,8 +61,8 @@ Modelling
    :members:
    :undoc-members:
 
-Evaluation
-----------
+Post-processing and evaluation
+------------------------------
 
 .. automodule:: multi_vector_simulator.E0_evaluation
    :members:
@@ -89,5 +92,9 @@ Output
    :undoc-members:
 
 .. automodule:: multi_vector_simulator.F1_plotting
+   :members:
+   :undoc-members:
+
+.. automodule:: multi_vector_simulator.F2_autoreport
    :members:
    :undoc-members:

--- a/src/multi_vector_simulator/A0_initialization.py
+++ b/src/multi_vector_simulator/A0_initialization.py
@@ -1,4 +1,7 @@
 r"""
+Module A0 - Initialization
+========================
+
 Module A0_initialization defines functions to parse user inputs to the MVS simulation.
     - Display welcome message with current version number
     - Parse command line arguments and set default values for MVS parameters if not provided

--- a/src/multi_vector_simulator/A1_csv_to_json.py
+++ b/src/multi_vector_simulator/A1_csv_to_json.py
@@ -1,4 +1,7 @@
 """
+Module A1 - Csv to json
+=======================
+
 Convert csv files to json file as input for the simulation.
 
 The default input csv files are stored in "/inputs/elements/csv".

--- a/src/multi_vector_simulator/B0_data_input_json.py
+++ b/src/multi_vector_simulator/B0_data_input_json.py
@@ -1,3 +1,7 @@
+"""
+Module B0 - Data input json
+=========================
+"""
 import logging
 import copy
 import json

--- a/src/multi_vector_simulator/C0_data_processing.py
+++ b/src/multi_vector_simulator/C0_data_processing.py
@@ -1,3 +1,27 @@
+"""
+Module C0 - Data processing
+===========================
+
+Module C0 prepares the data read from csv or json for simulation, ie. pre-processes it.
+- Verify input values with C1
+- Identify energyVectors and write them to project_data/sectors
+- Create an excess sink for each bus
+- Process start_date/simulation_duration to pd.datatimeindex (future: Also consider timesteplenghts)
+- Add economic parameters to json with C2
+- Calculate "simulation annuity" used in oemof model
+- Add demand sinks to energyVectors (this should actually be changed and demand sinks should be added to bus relative to input_direction, also see issue #179)
+- Translate input_directions/output_directions to bus names
+- Add missing cost data to automatically generated objects (eg. DSO transformers)
+- Read timeseries of assets and store into json (differ between one-column csv, multi-column csv)
+- Read timeseries for parameter of an asset, eg. efficiency
+- Parse list of inputs/outputs, eg. for chp
+- Define dso sinks, sources, transformer stations (this will be changed due to bug #119), also for peak demand pricing
+- Add a source if a conversion object is connected to a new input_direction (bug #186)
+- Define all necessary energyBusses and add all assets that are connected to them specifically with asset name and label
+- Multiply `maximumCap` of non-dispatchable sources by max(timeseries(kWh/kWp)) as the `maximumCap` is limiting the flow but we want to limit the installed capacity (see issue #446)
+"""
+
+
 import logging
 import os
 import sys
@@ -21,26 +45,6 @@ import multi_vector_simulator.B0_data_input_json as B0
 import multi_vector_simulator.C1_verification as C1
 import multi_vector_simulator.C2_economic_functions as C2
 import multi_vector_simulator.F0_output as F0
-
-"""
-Module C0 prepares the data read from csv or json for simulation, ie. pre-processes it. 
-- Verify input values with C1
-- Identify energyVectors and write them to project_data/sectors
-- Create an excess sink for each bus
-- Process start_date/simulation_duration to pd.datatimeindex (future: Also consider timesteplenghts)
-- Add economic parameters to json with C2
-- Calculate "simulation annuity" used in oemof model
-- Add demand sinks to energyVectors (this should actually be changed and demand sinks should be added to bus relative to input_direction, also see issue #179)
-- Translate input_directions/output_directions to bus names
-- Add missing cost data to automatically generated objects (eg. DSO transformers)
-- Read timeseries of assets and store into json (differ between one-column csv, multi-column csv)
-- Read timeseries for parameter of an asset, eg. efficiency
-- Parse list of inputs/outputs, eg. for chp
-- Define dso sinks, sources, transformer stations (this will be changed due to bug #119), also for peak demand pricing
-- Add a source if a conversion object is connected to a new input_direction (bug #186)
-- Define all necessary energyBusses and add all assets that are connected to them specifically with asset name and label
-- Multiply `maximumCap` of non-dispatchable sources by max(timeseries(kWh/kWp)) as the `maximumCap` is limiting the flow but we want to limit the installed capacity (see issue #446)
-"""
 
 
 def all(dict_values):

--- a/src/multi_vector_simulator/C1_verification.py
+++ b/src/multi_vector_simulator/C1_verification.py
@@ -1,4 +1,7 @@
 """
+Module C1 - Verification
+======================
+
 Module C1 is used to validate the input data compiled in A1 or read in B0.
 
 In A1/B0, the input parameters were parsed to str/bool/float/int. This module

--- a/src/multi_vector_simulator/C2_economic_functions.py
+++ b/src/multi_vector_simulator/C2_economic_functions.py
@@ -1,7 +1,7 @@
-# todo check whether this is the most recent version
-# - there were some project costs included wrongly,
-# and something with the replacement costs
 """
+Module C2 - Economic preprocessing
+==================================
+
 Module C2 performs the economic pre-processing of MVS' input parameters.
 It includes basic economic formulas.
 

--- a/src/multi_vector_simulator/D0_modelling_and_optimization.py
+++ b/src/multi_vector_simulator/D0_modelling_and_optimization.py
@@ -1,3 +1,24 @@
+"""
+Module D0 - Model building
+==========================
+
+Functional requirements of module D0:
+- measure time needed to build model
+- measure time needed to solve model
+- generate energy system model for oemof
+- create dictionary of components so that they can be used for constraints and some
+- raise warning if component not a (in mvs defined) oemof model type
+- add all energy conversion, energy consumption, energy production, energy storage devices model
+- plot network graph
+- at constraints to remote model
+- store lp file (optional)
+- start oemof simulation
+- process results by giving them to the next function
+- dump oemof results
+- add simulation parameters to dict values
+"""
+
+
 import logging
 import os
 import timeit
@@ -33,23 +54,6 @@ from multi_vector_simulator.utils.constants_json_strings import (
     OBJECTIVE_VALUE,
     SIMULTATION_TIME,
 )
-
-"""
-Functional requirements of module D0:
-- measure time needed to build model
-- measure time needed to solve model
-- generate energy system model for oemof
-- create dictionary of components so that they can be used for constraints and some
-- raise warning if component not a (in mvs defined) oemof model type
-- add all energy conversion, energy consumption, energy production, energy storage devices model
-- plot network graph
-- at constraints to remote model
-- store lp file (optional)
-- start oemof simulation
-- process results by giving them to the next function
-- dump oemof results
-- add simulation parameters to dict values 
-"""
 
 
 class WrongOemofAssetForGroupError(ValueError):

--- a/src/multi_vector_simulator/D1_model_components.py
+++ b/src/multi_vector_simulator/D1_model_components.py
@@ -1,4 +1,7 @@
 """
+Module D1 - Oemof components
+============================
+
 Module D1 includes all functions that are required to build an oemof model with adaptable components.
 
 - add transformer objects (fix, to be optimized)

--- a/src/multi_vector_simulator/D2_model_constraints.py
+++ b/src/multi_vector_simulator/D2_model_constraints.py
@@ -1,4 +1,7 @@
 """
+Module D2 - Model constraints
+=============================
+
 This module gathers all constraints that can be added to the MVS optimisation. 
 we will probably require another input CSV file or further parameters in simulation_settings.
 

--- a/src/multi_vector_simulator/E0_evaluation.py
+++ b/src/multi_vector_simulator/E0_evaluation.py
@@ -1,3 +1,13 @@
+"""
+Module E0 - evaluation
+====================
+
+Module E0 evaluates the oemof results and calculates the KPI
+- define dictionary entry for kpi matrix
+- define dictionary entry for cost matrix
+- store all results to matrix
+"""
+
 import logging
 
 import oemof.solph as solph
@@ -40,17 +50,6 @@ from multi_vector_simulator.utils.constants_output import (
     KPI_COST_MATRIX_ENTRIES,
     KPI_SCALAR_MATRIX_ENTRIES,
 )
-
-
-r"""
-Module E0 evaluation
-====================
-
-Module E0 evaluates the oemof results and calculates the KPI
-- define dictionary entry for kpi matrix
-- define dictionary entry for cost matrix
-- store all results to matrix
-"""
 
 
 def evaluate_dict(dict_values, results_main, results_meta):

--- a/src/multi_vector_simulator/E1_process_results.py
+++ b/src/multi_vector_simulator/E1_process_results.py
@@ -1,6 +1,7 @@
-r"""
+"""
 Module E1 process results
--------------------------
+=========================
+
 Module E1 processes the oemof results.
 - receive time series per bus for all assets
 - write time series to dictionary

--- a/src/multi_vector_simulator/E2_economics.py
+++ b/src/multi_vector_simulator/E2_economics.py
@@ -1,3 +1,23 @@
+"""
+Module E2 - Economic processing
+===============================
+
+The module processes the simulation results regarding economic parameters:
+- calculate lifetime expenditures based on variable energy flows
+- calculate lifetime investment costs
+- calculate present value of an asset
+- calculate revenue
+- calculate yearly cash flows of whole project for project lifetime (cash flow projection)
+- calculate fuel price expenditures calculate upfront investment costs
+- calculate operation management costs (FOM)
+- calculate upfront investment costs (UIC)
+- calculate annuity per asset
+- calculate annuity for the whole project
+- calculate net present value
+- calculate levelised cost of energy
+- calculate levelised cost of energy carriers (electricity, H2, heat)
+"""
+
 import logging
 import pandas as pd
 import warnings
@@ -43,25 +63,6 @@ from multi_vector_simulator.utils.constants_json_strings import (
     SPECIFIC_REPLACEMENT_COSTS_INSTALLED,
     SPECIFIC_REPLACEMENT_COSTS_OPTIMIZED,
 )
-
-r"""
-Module E3 economic processing
------------------------------
-The module processes the simulation results regarding economic parameters:
-- calculate lifetime expenditures based on variable energy flows
-- calculate lifetime investment costs
-- calculate present value of an asset
-- calculate revenue
-- calculate yearly cash flows of whole project for project lifetime (cash flow projection)
-- calculate fuel price expenditures calculate upfront investment costs
-- calculate operation management costs (FOM)
-- calculate upfront investment costs (UIC)
-- calculate annuity per asset
-- calculate annuity for the whole project
-- calculate net present value
-- calculate levelised cost of energy
-- calculate levelised cost of energy carriers (electricity, H2, heat)
-"""
 
 
 class MissingParametersForEconomicEvaluation(UserWarning):

--- a/src/multi_vector_simulator/E3_indicator_calculation.py
+++ b/src/multi_vector_simulator/E3_indicator_calculation.py
@@ -1,6 +1,6 @@
 r"""
-Module E3 indicator calculation
--------------------------------
+Module E3 - Indicator calculation
+==================================
 
 In module E3 the technical KPI are evaluated:
 - calculate renewable share

--- a/src/multi_vector_simulator/E4_verification.py
+++ b/src/multi_vector_simulator/E4_verification.py
@@ -1,3 +1,11 @@
+"""
+Module E4 - Verification of results
+===================================
+
+- Detect excessive excess generation
+- Verify that minimal renewable share constraint is adhered to
+"""
+
 import logging
 import pandas as pd
 from multi_vector_simulator.utils.constants_json_strings import (

--- a/src/multi_vector_simulator/F0_output.py
+++ b/src/multi_vector_simulator/F0_output.py
@@ -1,3 +1,19 @@
+"""
+Module F0 - Output
+==================
+
+The model F0 output defines all functions that store evaluation results to file.
+- Aggregate demand profiles to a total demand profile
+- Plot all energy flows for both 14 and 365 days for each energy bus
+- Store timeseries of all energy flows to excel (one sheet = one energy bus)
+- Execute function: plot optimised capacities as a barchart (F1)
+- Execute function: plot all annuities as a barchart (F1)
+- Store scalars/KPI to excel
+- Process dictionary so that it can be stored to Json
+- Store dictionary to Json
+"""
+
+
 import json
 import logging
 import os
@@ -47,20 +63,6 @@ from multi_vector_simulator.utils.constants_json_strings import (
     FIX_COST,
     ENERGY_BUSSES,
 )
-
-r"""
-Module F0 Output
-================
-The model F0 output defines all functions that store evaluation results to file.
-- Aggregate demand profiles to a total demand profile
-- Plot all energy flows for both 14 and 365 days for each energy bus
-- Store timeseries of all energy flows to excel (one sheet = one energy bus)
-- Execute function: plot optimised capacities as a barchart (F1)
-- Execute function: plot all annuities as a barchart (F1)
-- Store scalars/KPI to excel
-- Process dictionary so that it can be stored to Json
-- Store dictionary to Json
-"""
 
 
 def evaluate_dict(dict_values, path_pdf_report=None, path_png_figs=None):

--- a/src/multi_vector_simulator/F1_plotting.py
+++ b/src/multi_vector_simulator/F1_plotting.py
@@ -1,3 +1,15 @@
+r"""
+Module F1 - Plotting
+====================
+
+Module F1 describes all the functions that create plots.
+
+- creating graphs for energy flows
+- creating bar chart for capacity
+- creating pie chart for cost data
+- creating network graph for the model brackets only working on Ubuntu
+"""
+
 import logging
 import os
 import textwrap
@@ -52,15 +64,6 @@ from multi_vector_simulator.E1_process_results import (
     convert_demand_to_dataframe,
     convert_costs_to_dataframe,
 )
-
-r"""
-Module F1 describes all the functions that create plots.
-
-- creating graphs for energy flows
-- creating bar chart for capacity
-- creating pie chart for cost data
-- creating network graph for the model brackets only working on Ubuntu
-"""
 
 
 def convert_plot_data_to_dataframe(plot_data_dict, data_type):

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -1,4 +1,9 @@
-# This script generates a report of the simulation automatically, with all the important data.
+"""
+Module F2 - Autoreport
+======================
+
+This script generates a report of the simulation automatically, with all the important data.
+"""
 
 import base64
 import os

--- a/src/multi_vector_simulator/utils/constants.py
+++ b/src/multi_vector_simulator/utils/constants.py
@@ -1,3 +1,7 @@
+"""
+General Constants
+=================
+"""
 import os
 
 from multi_vector_simulator.utils.constants_json_strings import *

--- a/src/multi_vector_simulator/utils/constants_json_strings.py
+++ b/src/multi_vector_simulator/utils/constants_json_strings.py
@@ -1,4 +1,7 @@
 """
+Parameter constants
+===================
+
 Defines the strings of different json parameters
 Using variables rather than strings is helpful for typo prevention. A typo in a variable will
 raise an error where the variable was misspelled, whereas a typo in a string (dictionnary key)

--- a/src/multi_vector_simulator/utils/constants_output.py
+++ b/src/multi_vector_simulator/utils/constants_output.py
@@ -1,4 +1,7 @@
 """
+Output definition
+=================
+
 This file contains multiple lists of paramters that are written to the "scalars.xlsx" output file of the MVS.
 One should simply import new KPI names from constants.py or constants_json_strings.py
 and add them to the list to make them appear in the excel output sheet "scalars".

--- a/src/multi_vector_simulator/utils/data_parser.py
+++ b/src/multi_vector_simulator/utils/data_parser.py
@@ -1,6 +1,7 @@
 r"""
 Module data_parser
-================
+==================
+
 This module defines all functions to convert formats between EPA and MVS
 - Define similar parameters mapping between the EPA and MVS in MAP_EPA_MVS and MAP_MVS_EPA
 - Define which fields are expected in asset list of EPA for various assets' groups in EPA_ASSET_KEYS

--- a/src/multi_vector_simulator/utils/exceptions.py
+++ b/src/multi_vector_simulator/utils/exceptions.py
@@ -1,3 +1,9 @@
+"""
+Exceptions of the MVS
+=====================
+"""
+
+
 class MissingParameterError(ValueError):
     """Exception raised for missing parameters of a csv input file."""
 

--- a/src/multi_vector_simulator/utils/helpers.py
+++ b/src/multi_vector_simulator/utils/helpers.py
@@ -1,4 +1,7 @@
 """
+Helper functions
+================
+
 Util functions that are useful throughout the MVS
 
 Including:


### PR DESCRIPTION
Fix #641 

**Changes proposed in this pull request**:
- Improved `Code.rst` for RTD code documentation
- All `.py` files to add a module description for RTD on top

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [x] For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)