### PR TITLE
Feature/stratified therm storage

### DIFF
--- a/src/multi_vector_simulator/D1_model_components.py
+++ b/src/multi_vector_simulator/D1_model_components.py
@@ -31,6 +31,8 @@ from multi_vector_simulator.utils.constants_json_strings import (
     SOC_INITIAL,
     SOC_MAX,
     SOC_MIN,
+    REL_LOSSES,
+    ABS_LOSSES,
     STORAGE_CAPACITY,
     TIMESERIES,
     TIMESERIES_NORMALIZED,
@@ -577,6 +579,8 @@ def storage_fix(model, dict_asset, **kwargs):
         },  # maximum discharge possible in one timestep
         loss_rate=1
         - dict_asset[STORAGE_CAPACITY][EFFICIENCY][VALUE],  # from timestep to timestep
+        fixed_losses_absolute=dict_asset[STORAGE_CAPACITY][ABS_LOSSES][VALUE],
+        fixed_losses_relative=dict_asset[STORAGE_CAPACITY][REL_LOSSES][VALUE],
         min_storage_level=dict_asset[STORAGE_CAPACITY][SOC_MIN][VALUE],
         max_storage_level=dict_asset[STORAGE_CAPACITY][SOC_MAX][VALUE],
         initial_storage_level=dict_asset[STORAGE_CAPACITY][SOC_INITIAL][
@@ -640,6 +644,8 @@ def storage_optimize(model, dict_asset, **kwargs):
         },  # maximum discharge power
         loss_rate=1
         - dict_asset[STORAGE_CAPACITY][EFFICIENCY][VALUE],  # from timestep to timestep
+        fixed_losses_absolute=dict_asset[STORAGE_CAPACITY][ABS_LOSSES][VALUE],
+        fixed_losses_relative=dict_asset[STORAGE_CAPACITY][REL_LOSSES][VALUE],
         min_storage_level=dict_asset[STORAGE_CAPACITY][SOC_MIN][VALUE],
         max_storage_level=dict_asset[STORAGE_CAPACITY][SOC_MAX][VALUE],
         initial_storage_level=dict_asset[STORAGE_CAPACITY][SOC_INITIAL][

--- a/src/multi_vector_simulator/utils/constants.py
+++ b/src/multi_vector_simulator/utils/constants.py
@@ -265,6 +265,18 @@ EXTRA_CSV_PARAMETERS = {
         WARNING_TEXT: "allows defining the renewable share of the DSO supply (Values: Float). ",
         REQUIRED_IN_CSV_ELEMENTS: [ENERGY_PROVIDERS],
     },
+    REL_LOSSES: {
+        DEFAULT_VALUE: 0,
+        UNIT: TYPE_FLOAT,
+        WARNING_TEXT: "allows considering relative thermal energy losses (Values: Float)",
+        REQUIRED_IN_CSV_ELEMENTS: [ENERGY_STORAGE],
+    },
+    ABS_LOSSES: {
+        DEFAULT_VALUE: 0,
+        UNIT: TYPE_FLOAT,
+        WARNING_TEXT: "allows considering relative thermal energy losses (Values: Float)",
+        REQUIRED_IN_CSV_ELEMENTS: [ENERGY_STORAGE],
+    },
 }
 
 ENERGY_CARRIER_UNIT = "energy_carrier_unit"

--- a/src/multi_vector_simulator/utils/constants_json_strings.py
+++ b/src/multi_vector_simulator/utils/constants_json_strings.py
@@ -109,6 +109,8 @@ STORAGE_CAPACITY = "storage capacity"
 SOC_INITIAL = "soc_initial"
 SOC_MAX = "soc_max"
 SOC_MIN = "soc_min"
+REL_LOSSES = "rel_thermal_losses"
+ABS_LOSSES = "abs_thermal_losses"
 
 # Constraints
 CONSTRAINTS = "constraints"


### PR DESCRIPTION
Fix Issue https://github.com/rl-institut/multi-vector-simulator/issues/667

With this PR it is possible to model the stratified thermal storage component, which has been developed in [oemof.thermal](https://github.com/oemof/oemof-thermal), passing two further parameter `fixed_losses_relative` and `fixed_losses_absolute` to the storage component.

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [ ] Update the CHANGELOG.md
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
