### PR TITLE
Disable the logging of imported and third-party libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Here is a template for new release sections
 - Add assertion `sum(attributed_costs)==cost_total` (for single-vector system) (#613)
 - Benchmark test for renewable share (`TestTechnicalKPI.test_renewable_factor_and_renewable_share_of_local_generation()`) (#613)
 - Github actions workflow: update apt-get before installing pre-dependencies (#729)
+- Got rid of logging messages of imported libraries in the log file (#725)
 
 ## [0.5.3] - 2020-12-08
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,6 +81,7 @@ copyright = "2019, Reiner Lemoine Institut and Martha M. Hoffmann"
 author = "Reiner Lemoine Institut and Martha M. Hoffmann"
 
 from multi_vector_simulator.version import version_num
+
 release = version_num
 
 # -- General configuration ---------------------------------------------------

--- a/src/multi_vector_simulator/A0_initialization.py
+++ b/src/multi_vector_simulator/A0_initialization.py
@@ -498,10 +498,17 @@ def process_user_arguments(
         screen_level=screen_level,
     )
 
-    logger.getLogger("asyncio").setLevel(logging.ERROR)
-    logger.getLogger("asyncio.coroutines").setLevel(logging.ERROR)
-    logger.getLogger("websockets.server").setLevel(logging.ERROR)
-    logger.getLogger("websockets.protocol").setLevel(logging.ERROR)
+    # Disable log messages of external libraries saving into the log file, unless they are ERROR or CRITICAL level
+    for ext_lib_logger in (
+        "asyncio",
+        "asyncio.coroutines",
+        "websockets.server",
+        "websockets.protocol",
+        "websockets.client",
+        "urllib3.connectionpool",
+        "PIL.PngImagePlugin",
+    ):
+        logger.getLogger(ext_lib_logger).setLevel(logging.ERROR)
 
     if welcome_text is not None:
         # display welcome text

--- a/src/multi_vector_simulator/A0_initialization.py
+++ b/src/multi_vector_simulator/A0_initialization.py
@@ -498,6 +498,11 @@ def process_user_arguments(
         screen_level=screen_level,
     )
 
+    logger.getLogger("asyncio").setLevel(logging.ERROR)
+    logger.getLogger("asyncio.coroutines").setLevel(logging.ERROR)
+    logger.getLogger("websockets.server").setLevel(logging.ERROR)
+    logger.getLogger("websockets.protocol").setLevel(logging.ERROR)
+
     if welcome_text is not None:
         # display welcome text
         logging.info(welcome_text)


### PR DESCRIPTION
Fix #717 

**Changes proposed in this pull request**:
- Remove logging of log messages from third party libraries in the log file

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
