### PR TITLE
Update apt-get before installing pre-dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Install pre-dependencies
         run: |
+            sudo apt-get update
             sudo apt-get install coinor-cbc
             sudo apt-get install graphviz
             sudo apt-get install wkhtmltopdf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Here is a template for new release sections
 - Added storage to the table in autoreport listing the energy system components (#686)
 - Add assertion `sum(attributed_costs)==cost_total` (for single-vector system) (#613)
 - Benchmark test for renewable share (`TestTechnicalKPI.test_renewable_factor_and_renewable_share_of_local_generation()`) (#613)
+- Github actions workflow: update apt-get before installing pre-dependencies (#729)
 
 ## [0.5.3] - 2020-12-08
 


### PR DESCRIPTION
Fix github actions pre-dependencies installation.

**Changes proposed in this pull request**:
- Update apt-get before installing pre-dependencies in github actions workflow



*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
