### PR TITLE
Reformat KPI energy sector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,11 @@ Here is a template for new release sections
 - Explanation in MVS_parameters_list.csv on how to deactivate the RES constraint. (#752)
 - Add the new parameter `scenario_description` to input files and docs and a section in autoreport describing the scenario being simulated (#722)
 - Add a new sub-section in RTD describing the suite of post-simulation tests carried out through functions in E4_verification.py (#753)
+- Add KPI individual sectors to the report (#757)
 
 ### Changed
 - Fix xlrd to xlrd==1.2.0 in requirements/default.txt (#716)
+- Format KPI_UNCOUPLED_DICT to a `pd.DataFrame` (#757) 
 ### Removed
 -
 ### Fixed

--- a/src/multi_vector_simulator/E0_evaluation.py
+++ b/src/multi_vector_simulator/E0_evaluation.py
@@ -45,6 +45,7 @@ from multi_vector_simulator.utils.constants_json_strings import (
     LABEL,
     INSTALLED_CAP,
     TIMESERIES_SOC,
+    KPI_UNCOUPLED_DICT,
 )
 
 from multi_vector_simulator.utils.constants_output import (
@@ -185,6 +186,11 @@ def evaluate_dict(dict_values, results_main, results_meta):
     E4.maximum_emissions_test(dict_values)
     E4.detect_excessive_excess_generation_in_bus(dict_values)
     E4.verify_state_of_charge(dict_values)
+
+    # Format KPI about energy generation into a pd.DataFrame
+    dict_values[KPI][KPI_UNCOUPLED_DICT] = pd.DataFrame.from_dict(
+        dict_values[KPI][KPI_UNCOUPLED_DICT], orient="index"
+    )
 
 
 def store_result_matrix(dict_kpi, dict_asset):

--- a/src/multi_vector_simulator/E3_indicator_calculation.py
+++ b/src/multi_vector_simulator/E3_indicator_calculation.py
@@ -291,6 +291,7 @@ def add_total_renewable_and_non_renewable_energy_origin(dict_values):
         renewable_origin.update({sector: 0})
         non_renewable_origin.update({sector: 0})
 
+    # Aggregate the total generation of non renewable and renewable energy in the LES
     for asset in dict_values[ENERGY_PRODUCTION]:
         if RENEWABLE_ASSET_BOOL in dict_values[ENERGY_PRODUCTION][asset]:
             sector = dict_values[ENERGY_PRODUCTION][asset][ENERGY_VECTOR]
@@ -313,6 +314,7 @@ def add_total_renewable_and_non_renewable_energy_origin(dict_values):
         }
     )
 
+    # Aggregate the total use of non renewable and renewable energy at DSO level
     for dso in dict_values[ENERGY_PROVIDERS]:
         sector = dict_values[ENERGY_PROVIDERS][dso][ENERGY_VECTOR]
 

--- a/src/multi_vector_simulator/E3_indicator_calculation.py
+++ b/src/multi_vector_simulator/E3_indicator_calculation.py
@@ -410,7 +410,6 @@ def add_renewable_share_of_local_generation(dict_values):
             )
         }
     )
-    return
 
 
 def add_renewable_factor(dict_values):
@@ -547,8 +546,6 @@ def add_degree_of_autonomy(dict_values):
         f"Calculated the {DEGREE_OF_AUTONOMY}: {round(degree_of_autonomy, 2)}"
     )
     logging.info(f"Calculated the {DEGREE_OF_AUTONOMY} of the LES.")
-
-    return
 
 
 def equation_degree_of_autonomy(total_generation, total_demand):
@@ -750,8 +747,6 @@ def add_onsite_energy_fraction(dict_values):
     )
     logging.info(f"Calculated the {ONSITE_ENERGY_FRACTION} of the LES.")
 
-    return
-
 
 def equation_onsite_energy_fraction(total_generation, total_feedin):
     """
@@ -841,8 +836,6 @@ def add_onsite_energy_matching(dict_values):
     )
     logging.info(f"Calculated the {ONSITE_ENERGY_MATCHING} of the LES.")
 
-    return
-
 
 def equation_onsite_energy_matching(
     total_generation, total_feedin, total_excess, total_demand
@@ -905,7 +898,6 @@ def calculate_emissions_from_flow(dict_asset):
     """
     emissions = dict_asset[TOTAL_FLOW][VALUE] * dict_asset[EMISSION_FACTOR][VALUE]
     dict_asset.update({TOTAL_EMISSIONS: {VALUE: emissions, UNIT: UNIT_EMISSIONS}})
-    return
 
 
 def add_total_emissions(dict_values):
@@ -937,7 +929,6 @@ def add_total_emissions(dict_values):
         f"Calculated the {TOTAL_EMISSIONS}: {round(emissions, 2)} {UNIT_EMISSIONS}."
     )
     logging.info(f"Calculated the {TOTAL_EMISSIONS} ({UNIT_EMISSIONS}) of the LES.")
-    return
 
 
 def add_specific_emissions_per_electricity_equivalent(dict_values):
@@ -979,7 +970,6 @@ def add_specific_emissions_per_electricity_equivalent(dict_values):
     logging.info(
         f"Calculated the {SPECIFIC_EMISSIONS_ELEQ} ({UNIT_SPECIFIC_EMISSIONS}) of the LES."
     )
-    return
 
 
 def add_levelized_cost_of_energy_carriers(dict_values):
@@ -1157,4 +1147,3 @@ def weighting_for_sector_coupled_kpi(dict_values, kpi_name):
     )
     # Describes system wide total of the energy equivalent of the kpi
     dict_values[KPI][KPI_SCALARS_DICT].update({kpi_name: total_energy_equivalent})
-    return

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -71,6 +71,8 @@ from multi_vector_simulator.utils.constants_json_strings import (
     WARNINGS,
     SIMULATION_RESULTS,
     SCENARIO_DESCRIPTION,
+    KPI,
+    KPI_UNCOUPLED_DICT,
 )
 
 from multi_vector_simulator.E1_process_results import (
@@ -754,6 +756,11 @@ def create_app(results_json, path_sim_output=None):
     df_scalar_matrix = convert_scalar_matrix_to_dataframe(results_json)
     df_cost_matrix = convert_cost_matrix_to_dataframe(results_json)
     df_kpi_scalars = convert_scalars_to_dataframe(results_json)
+    df_kpi_sectors = results_json[KPI][KPI_UNCOUPLED_DICT]
+    # Formats the kpi_sectors dataframe for nicer display
+    cols = list(df_kpi_sectors.columns)
+    df_kpi_sectors["KPI"] = df_kpi_sectors.index  #
+    df_kpi_sectors = df_kpi_sectors[["KPI"] + cols]
 
     # Obtain the scenario description text provided by the user from the JSON results file
     scenario_description = results_json[PROJECT_DATA][SCENARIO_DESCRIPTION]
@@ -956,9 +963,9 @@ def create_app(results_json, path_sim_output=None):
                                 ),
                             ),
                             insert_body_text(
-                                "This results in the following KPI of the dispatch:"
+                                "This results in the following KPI of the dispatch per energy sector:"
                             ),
-                            # TODO the table with renewable share, emissions, total renewable generation, etc.
+                            make_dash_data_table(df_kpi_sectors),
                         ],
                     ),
                     insert_subsection(

--- a/tests/test_benchmark_KPI.py
+++ b/tests/test_benchmark_KPI.py
@@ -405,13 +405,10 @@ class TestTechnicalKPI:
             path_output_folder=os.path.join(TEST_OUTPUT_PATH, use_case),
         )
         # Check for RENEWABLE_FACTOR and RENEWABLE_SHARE_OF_LOCAL_GENERATION:
-        with open(
-            os.path.join(
-                TEST_OUTPUT_PATH, use_case, JSON_WITH_RESULTS + JSON_FILE_EXTENSION
-            ),
-            "r",
-        ) as results:
-            data = json.load(results)
+        results = os.path.join(
+            TEST_OUTPUT_PATH, use_case, JSON_WITH_RESULTS + JSON_FILE_EXTENSION
+        )
+        data = load_json(results)
 
         # Get total flow of PV
         total_res_local = data[ENERGY_PRODUCTION]["pv_plant_01"][TOTAL_FLOW][VALUE]
@@ -436,20 +433,20 @@ class TestTechnicalKPI:
             data[KPI][KPI_SCALARS_DICT][TOTAL_NON_RENEWABLE_ENERGY_USE]
             == total_supply_dso
         ), "The non-renewable energy use was expected to be all grid supply, but this does not hold true."
-        assert data[KPI][KPI_SCALARS_DICT][RENEWABLE_FACTOR] == (total_res_local) / (
+        assert data[KPI][KPI_SCALARS_DICT][RENEWABLE_FACTOR] == total_res_local / (
             total_res_local + total_supply_dso
         ), f"The {RENEWABLE_FACTOR} is not as expected."
-        assert data[KPI][KPI_UNCOUPLED_DICT][RENEWABLE_FACTOR]["Electricity"] == (
-            total_res_local
-        ) / (
-            total_res_local + total_supply_dso
+        assert data[KPI][KPI_UNCOUPLED_DICT].loc[
+            RENEWABLE_FACTOR, "Electricity"
+        ] == pytest.approx(
+            total_res_local / (total_res_local + total_supply_dso)
         ), f"The {RENEWABLE_FACTOR} is not as expected."
         assert (
             data[KPI][KPI_SCALARS_DICT][RENEWABLE_SHARE_OF_LOCAL_GENERATION] == 1
         ), f"The {RENEWABLE_SHARE_OF_LOCAL_GENERATION} is not as expected."
         assert (
-            data[KPI][KPI_UNCOUPLED_DICT][RENEWABLE_SHARE_OF_LOCAL_GENERATION][
-                "Electricity"
+            data[KPI][KPI_UNCOUPLED_DICT].loc[
+                RENEWABLE_SHARE_OF_LOCAL_GENERATION, "Electricity"
             ]
             == 1
         ), f"The {RENEWABLE_SHARE_OF_LOCAL_GENERATION} is not as expected."


### PR DESCRIPTION
Addresses part of #703

**Changes proposed in this pull request**:
- Format KPI_UNCOUPLED_DICT to a `pd.DataFrame` 
- Add KPI individual sectors to the report

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
