### PR TITLE
Fix/emission constraint test

### DIFF
--- a/tests/test_D2_model_constraints.py
+++ b/tests/test_D2_model_constraints.py
@@ -188,9 +188,7 @@ class TestConstraints:
             model = D0.model_building.adding_assets_to_energysystem_model(
                 dict_values, dict_model, model
             )
-            local_energy_system = solph.Model(model)
-            logging.debug("Created oemof model based on created components and busses.")
-            return dict_values, local_energy_system, dict_model
+            return dict_values, model, dict_model
 
         self.dict_values, self.model, self.dict_model = run_parts()
         self.exp_emission_limit = 1000
@@ -205,7 +203,7 @@ class TestConstraints:
 
     def test_constraint_maximum_emissions(self):
         model = D2.constraint_maximum_emissions(
-            model=self.model, dict_values=self.dict_values
+            model=solph.Model(self.model), dict_values=self.dict_values
         )
         assert (
             model.integral_limit_emission_factor.NoConstraint[0]
@@ -214,7 +212,7 @@ class TestConstraints:
 
     def test_add_constraints_maximum_emissions(self):
         model = D2.add_constraints(
-            local_energy_system=self.model,
+            local_energy_system=solph.Model(self.model),
             dict_values=self.dict_values,
             dict_model=self.dict_model,
         )
@@ -238,8 +236,8 @@ class TestConstraints:
             }
         )
         model = D2.add_constraints(
-            local_energy_system=self.model,
             dict_values=self.dict_values,
+            local_energy_system=solph.Model(self.model),
             dict_model=self.dict_model,
         )
         assert (
@@ -266,8 +264,8 @@ class TestConstraints:
             }
         )
         model = D2.add_constraints(
-            local_energy_system=self.model,
             dict_values=self.dict_values,
+            local_energy_system=solph.Model(self.model),
             dict_model=self.dict_model,
         )
         assert (

--- a/tests/test_D2_model_constraints.py
+++ b/tests/test_D2_model_constraints.py
@@ -236,13 +236,13 @@ class TestConstraints:
             }
         )
         model = D2.add_constraints(
-            dict_values=self.dict_values,
             local_energy_system=solph.Model(self.model),
+            dict_values=dict_values,
             dict_model=self.dict_model,
         )
         assert (
-            model.integral_limit_emission_factor.NoConstraint[0]
-            == self.exp_emission_limit
+            hasattr(model, "integral_limit_emission_factor")
+            == False
         ), f"When maximum_emission is None, no emission constraint should be added to the ESM."
 
     """

--- a/tests/test_D2_model_constraints.py
+++ b/tests/test_D2_model_constraints.py
@@ -264,8 +264,8 @@ class TestConstraints:
             }
         )
         model = D2.add_constraints(
-            dict_values=self.dict_values,
             local_energy_system=solph.Model(self.model),
+            dict_values=dict_values,
             dict_model=self.dict_model,
         )
         assert (

--- a/tests/test_D2_model_constraints.py
+++ b/tests/test_D2_model_constraints.py
@@ -211,9 +211,13 @@ class TestConstraints:
         ), f"Either the maximum emission constraint has not been added or the wrong limit has been added; limit is {model.integral_limit_emission_factor.NoConstraint[0]}."
 
     def test_add_constraints_maximum_emissions(self):
+        dict_values = self.dict_values.copy()
+        dict_values.update(
+            {MINIMAL_RENEWABLE_FACTOR: {VALUE: 0},}
+        )
         model = D2.add_constraints(
             local_energy_system=solph.Model(self.model),
-            dict_values=self.dict_values,
+            dict_values=dict_values,
             dict_model=self.dict_model,
         )
         assert (
@@ -227,11 +231,7 @@ class TestConstraints:
             {
                 CONSTRAINTS: {
                     MAXIMUM_EMISSIONS: {VALUE: None},
-                    MINIMAL_RENEWABLE_FACTOR: {
-                        VALUE: self.dict_values[CONSTRAINTS][MINIMAL_RENEWABLE_FACTOR][
-                            VALUE
-                        ]
-                    },
+                    MINIMAL_RENEWABLE_FACTOR: {VALUE: 0},
                 }
             }
         )

--- a/tests/test_D2_model_constraints.py
+++ b/tests/test_D2_model_constraints.py
@@ -241,8 +241,7 @@ class TestConstraints:
             dict_model=self.dict_model,
         )
         assert (
-            hasattr(model, "integral_limit_emission_factor")
-            == False
+            hasattr(model, "integral_limit_emission_factor") == False
         ), f"When maximum_emission is None, no emission constraint should be added to the ESM."
 
     """


### PR DESCRIPTION
Fix #Issue

**Changes proposed in this pull request**:
- Fixed tests for maximum emissions constraint in `test_D2_model_constraints.py` by using raw model (oemof.solph) for each test.

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [ ] Update the CHANGELOG.md
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
