### PR TITLE
Delete warning message that is outdated as #559 is solved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Here is a template for new release sections
 - Remove `STORE_OEMOF_RESULTS` variable (#675)
 - Remove `F0.select_essential_results()` (#675)
 - Removed `DSM` and `TYPE_ASSET` from `input_template/energyConsumption.csv`, also in `constants.py` (#726)
-
+- Removed warning message that is outdated as #559 is solved (777)
 ### Fixed
 - Minor typos in D0, E4 and test_E4 files (#739)
 - `utils.data_parser.convert_epa_params_to_mvs()` and `utils.data_parser.convert_mvs_params_to_epa()` now parse succesfully input files generated from EPA (#675)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,8 @@ Here is a template for new release sections
 - Remove `STORE_OEMOF_RESULTS` variable (#675)
 - Remove `F0.select_essential_results()` (#675)
 - Removed `DSM` and `TYPE_ASSET` from `input_template/energyConsumption.csv`, also in `constants.py` (#726)
-- Removed warning message that is outdated as #559 is solved (777)
+- Removed warning message about excess energy calculation that is outdated as #559 is solved (777)
+
 ### Fixed
 - Minor typos in D0, E4 and test_E4 files (#739)
 - `utils.data_parser.convert_epa_params_to_mvs()` and `utils.data_parser.convert_mvs_params_to_epa()` now parse succesfully input files generated from EPA (#675)

--- a/src/multi_vector_simulator/E3_indicator_calculation.py
+++ b/src/multi_vector_simulator/E3_indicator_calculation.py
@@ -259,10 +259,7 @@ def calculate_electricity_equivalent_for_a_set_of_aggregated_values(
     logging.info(
         f"The {kpi_name+SUFFIX_ELECTRICITY_EQUIVALENT} of the LES is: {round(total_electricity_equivalent)} kWheleq."
     )
-    if kpi_name == TOTAL_EXCESS:
-        logging.warning(
-            f"The calculation of the {TOTAL_EXCESS} per sector and their energy equivalent may currently be faulty. Please refer to issue #559"
-        )
+
     return total_electricity_equivalent
 
 


### PR DESCRIPTION
Fix #559

**Changes proposed in this pull request**:
-  Delete warning message that is outdated as #559 is solved 

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
