### PR TITLE
Avoid class 'numpy.int32' error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Here is a template for new release sections
 - Fix issue (#769): Fix argument parsing and error messages of `mvs_report` command (#770)
 - Fix issue (#756): Avoid crashing report generation when internet not available (#770)
 - Fixed display of math equations in RTD (#730)
+- Fix numpy.int32 error in B0 (#778)
 
 ## [0.5.4] - 2020-12-18
 

--- a/src/multi_vector_simulator/B0_data_input_json.py
+++ b/src/multi_vector_simulator/B0_data_input_json.py
@@ -178,7 +178,7 @@ def convert_from_special_types_to_json(o):
         json-storable value.
 
     """
-    if isinstance(o, np.int64):
+    if isinstance(o, np.int64) or isinstance(o, np.int32):
         answer = int(o)
     elif isinstance(o, bool) or isinstance(o, str):
         answer = o


### PR DESCRIPTION


**Changes proposed in this pull request**:
- Update B0_data_input_json.py

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
