### PR TITLE
Patch/precision limit to 10e 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Here is a template for new release sections
 - Added net zero energy KPI `degree of NZE` with `E3.equation_degree_of_net_zero_energy()` and `E3.add_degree_of_net_zero_energy()` (#776)
 - Added tests for `E3.equation_degree_of_net_zero_energy()` and `E3.add_degree_of_net_zero_energy()` (#776)
 - Added information about degree of NZE to RTD (#776)
+- Function `E1.cut_below_micro` to round decision variables (capacities, flows) below threshold of plus/minus 10^-6 to 0, add warnings if negative value larger then threshold (invalid result). Includes pytests (#791)
 
 ### Changed
 - Fix xlrd to xlrd==1.2.0 in requirements/default.txt (#716)
@@ -70,6 +71,7 @@ Here is a template for new release sections
 - Adapted structure of component models in RTD to mirror EPA and MVS input data (#792)
 - Refactor module imports in `cli.py` and `server.py` (#783)
 - Limit index of availability timeseries to simulation timeindex (`C0.define_availability_of_peak_demand_pricing_assets`) (#783)
+- Call `E1.cut_below_micro` in `E1.get_flows`, `E1.get_optimal_cap` and `E1.get_storage_results` (#791) 
 
 ### Removed
 - Remove `MissingParameterWarning` and use `logging.warning` instead (#761)

--- a/docs/Model_Assumptions.rst
+++ b/docs/Model_Assumptions.rst
@@ -615,6 +615,13 @@ The perfect foresight can lead to suspicious dispatch of assets, for example cha
 
 .. _limitations-missing-kpi:
 
+
+Optimization precision
+######################
+
+The MVS makes use of the open energy modelling framework (oemof) by using oemof-solph. It is defined that the energy system is solved with the `cbc-solver` and a `ratioGap=0.03`. This influences the precision of the optimized decision variables, ie. the optimized capacities as well as the dispatch of the assets.
+In some cases it was possible to observe that the precision allowed minimal and also negative dispatch or capacities (scale: <10e-6). In case of storage assets, this can lead to SOC curves with negative values or values far above the viable value 1. As the reason for these inconsistencies is known, the MVS enforces minimal capacities and dispatch of 10e-6, ie. all capacities or flows smaller then 10e-9 are set to zero. This is applied to absolute values, so that irregular (and incorrect) values for decision variables can still be detected.
+
 Extension of KPIs necessary
 ###########################
 

--- a/docs/Model_Assumptions.rst
+++ b/docs/Model_Assumptions.rst
@@ -619,8 +619,19 @@ The perfect foresight can lead to suspicious dispatch of assets, for example cha
 Optimization precision
 ######################
 
-The MVS makes use of the open energy modelling framework (oemof) by using oemof-solph. It is defined that the energy system is solved with the `cbc-solver` and a `ratioGap=0.03`. This influences the precision of the optimized decision variables, ie. the optimized capacities as well as the dispatch of the assets.
-In some cases it was possible to observe that the precision allowed minimal and also negative dispatch or capacities (scale: <10e-6). In case of storage assets, this can lead to SOC curves with negative values or values far above the viable value 1. As the reason for these inconsistencies is known, the MVS enforces minimal capacities and dispatch of 10e-6, ie. all capacities or flows smaller then 10e-9 are set to zero. This is applied to absolute values, so that irregular (and incorrect) values for decision variables can still be detected.
+:Limitation:
+
+Marginal capacities and flows below a threshold of 10^-6 are rounded to zero.
+
+:Reason:
+
+The MVS makes use of the open energy modelling framework (oemof) by using oemof-solph. For the MVS, we use the `cbc-solver` and at a `ratioGap=0.03`. This influences the precision of the optimized decision variables, ie. the optimized capacities as well as the dispatch of the assets.
+In some cases the dispatch and capacities vary around 0 with fluctuations of the order of floating point precision (well below <10e-6), thus resulting in marginal and also marginal negative dispatch or capacities. When calculating KPI from these decision variables, the results can be nonsensical, for example leading to SoC curves with negative values or values far above the viable value 1.
+As the reason for these inconsistencies is known, the MVS enforces the capacities and dispatch of to be above 10e-6, ie. all capacities or flows smaller than that are set to zero. This is applied to absolute values, so that irregular (and incorrect) values for decision variables can still be detected.
+
+:Implications:
+
+If your energy system has demand or resource profiles that include marginal values below the threshold of 10^-6, the MVS will not result in appropriate results. For example, that means that if you have an energy system with usually is measured in `MW` but one demand is in the `W` range, the dispatch of assets serving this minor demand is not displayed correctly. Please chose `kW` or even `W` as a base unit then.
 
 Extension of KPIs necessary
 ###########################

--- a/src/multi_vector_simulator/E1_process_results.py
+++ b/src/multi_vector_simulator/E1_process_results.py
@@ -76,6 +76,109 @@ ASSET_GROUPS_DEFINED_BY_INFLUX = [ENERGY_CONSUMPTION]
 ASSET_GROUPS_DEFINED_BY_OUTFLUX = [ENERGY_CONVERSION, ENERGY_PRODUCTION]
 
 
+def cut_below_pico(value, label):
+    r"""
+    Function trims results of oemof optimization to positive values and rounds to 0, if within a certain precision threshold (of -10^-6)
+
+    Oemof termination is dependent on the simulation settings of oemof solph. Thus, it can terminate the optimization if the results are with certain bounds, which can sometimes lead to negative decision variables (capacities, flows). Negative values do not make sense in this context. If the values are between -10^-6 and 0, we assume that they can be rounded to 0, as they result from the precision settings of the solver. In that case the value is overwritten for the futher post-processing. This should also avoid SOC timeseries with doubtful values outside of [0,1]. If any value is a higher negative value then the threshold, its value is not changed but a warning raised.
+    Similarily, if a positive devision variable is detected that has a value lower then the theshold, it is assumed that this only happends because of the solver settings, and the values below the theshold are rounded to 0.
+
+    Parameters
+    ----------
+    value: float or pd.Series
+        Decision variable determined by oemof
+
+    label: str
+        String to be mentioned in the debug messages
+
+    Returns
+    -------
+
+    value: float of pd.Series
+        Decision variable with rounded values in case that slight negative values or positive values were observed.
+
+    Notes
+    -----
+
+    Tested with:
+    - E1.test_cut_below_pico_scalar_value_below_0_larger_treshhold
+    - E1.test_cut_below_pico_scalar_value_below_0_smaller_treshhold
+    - E1.test_cut_below_pico_scalar_value_0
+    - E1.test_cut_below_pico_scalar_value_larger_0
+    - E1.test_cut_below_pico_scalar_value_larger_0_smaller_threshold
+    - E1.test_cut_below_pico_pd_Series_below_0_larger_treshhold
+    - E1.test_cut_below_pico_pd_Series_below_0_smaller_treshhold
+    - E1.test_cut_below_pico_pd_Series_0
+    - E1.test_cut_below_pico_pd_Series_larger_0
+    - E1.test_cut_below_pico_pd_Series_larger_0_smaller_treshold
+    """
+    treshhold = 10 ** (-6)
+    text_block_start = f"The value of {label} is below 0"
+    text_block_set_0 = f"Negative value (s) are smaller then {-treshhold}. This is likely a result of the termination/precision settings of the cbc solver. As the difference is marginal, the value will be set to 0. "
+    text_block_oemof = "This is so far below 0, that the value is not changed. All oemof decision variables should be positive so this needs to be investigated. "
+
+    # flows
+    if isinstance(value, pd.Series):
+        # Identifies any negative values. Decision variables should not have a negative value
+        if (value < 0).any():
+            log_msg = text_block_start
+            # Counts the incidents, in which the value is below 0.
+            if isinstance(value, pd.Series):
+                instances = sum(value < 0)
+                log_msg += f" in {instances} instances. "
+            # Checks that all values are at least within the treshhold for negative values.
+            if (value > -treshhold).all():
+                log_msg += text_block_set_0
+                logging.debug(log_msg)
+                value = value.clip(lower=0)
+            # If any value has a large negative value (lower then threshhold), no values are changed.
+            else:
+                test = value.clip(upper=-treshhold).abs()
+                log_msg += f"At least one value is exceeds the scale of {-treshhold}. The highest negative value is -{max(test)}. "
+                log_msg += text_block_oemof
+                logging.warning(log_msg)
+
+        # Determine if there are any positive values that are between 0 and the threshold:
+        # Clip to interval
+        positive_threshold = value.clip(lower=0, upper=treshhold)
+        # Determine instances in which bounds are met: 1=either 0 or larger threshold, 0=smaller treshold
+        positive_threshold = (positive_threshold == 0) + (
+            positive_threshold == treshhold
+        )
+        # Instances in which values are in determined interval:
+        instances = len(value) - sum(positive_threshold)
+        if instances > 0:
+            logging.debug(
+                f"There are {instances} instances in which there are positive values smaller then the threshold."
+            )
+            # Multiply with positive_threshold (1=either 0 or larger threshold, 0=smaller treshold)
+            value = value * positive_threshold
+
+    # capacities
+    else:
+        # Value is lower 0, which should not be possible for decision variables
+        if value < 0:
+            log_msg = text_block_start
+            # Value between [threshold, 0] = [-10**(-6)], ie. is so small that it can be neglected.
+            if value > -treshhold:
+                log_msg += text_block_set_0
+                logging.debug(log_msg)
+                value = 0
+            # Value is below 0 but already large enough that it should not be neglected.
+            else:
+                log_msg += f"The value exceeds the scale of {-treshhold}, with {value}."
+                log_msg += text_block_oemof
+                logging.warning(log_msg)
+        # Value is above 0 but below threshold, should be rounded
+        elif value < treshhold:
+            logging.debug(
+                f"The positive value {value} is below the {treshhold}, and rounded to 0."
+            )
+            value = 0
+
+    return value
+
+
 def get_timeseries_per_bus(dict_values, bus_data):
     r"""
     Reads simulation results of all busses and stores time series.
@@ -174,16 +277,23 @@ def get_storage_results(settings, storage_bus, dict_asset):
     power_charge = storage_bus["sequences"][
         ((dict_asset[INFLOW_DIRECTION], dict_asset[LABEL]), "flow")
     ]
+    power_charge = cut_below_pico(power_charge, dict_asset[LABEL] + " charge flow")
     add_info_flows(settings, dict_asset[INPUT_POWER], power_charge)
 
     power_discharge = storage_bus["sequences"][
         ((dict_asset[LABEL], dict_asset[OUTFLOW_DIRECTION]), "flow")
     ]
+    power_discharge = cut_below_pico(
+        power_discharge, dict_asset[LABEL] + " discharge flow"
+    )
+
     add_info_flows(settings, dict_asset[OUTPUT_POWER], power_discharge)
 
     capacity = storage_bus["sequences"][
         ((dict_asset[LABEL], TYPE_NONE), "storage_content")
     ]
+    capacity = cut_below_pico(capacity, dict_asset[LABEL] + " storage capacity")
+
     add_info_flows(settings, dict_asset[STORAGE_CAPACITY], capacity)
 
     if OPTIMIZE_CAP in dict_asset:
@@ -467,7 +577,7 @@ def get_optimal_cap(bus, dict_asset, flow_tuple):
             and (flow_tuple, "invest") in bus["scalars"]
         ):
             optimal_capacity = bus["scalars"][(flow_tuple, "invest")]
-
+            optimal_capacity = cut_below_pico(optimal_capacity, dict_asset[LABEL])
             if TIMESERIES_PEAK in dict_asset:
                 if dict_asset[TIMESERIES_PEAK][VALUE] > 0:
                     dict_asset.update(
@@ -536,6 +646,7 @@ def get_flow(settings, bus, dict_asset, flow_tuple):
 
     """
     flow = bus["sequences"][(flow_tuple, "flow")]
+    cut_below_pico(flow, dict_asset[LABEL] + " flow")
     add_info_flows(settings, dict_asset, flow)
 
     logging.debug(

--- a/src/multi_vector_simulator/E1_process_results.py
+++ b/src/multi_vector_simulator/E1_process_results.py
@@ -76,7 +76,7 @@ ASSET_GROUPS_DEFINED_BY_INFLUX = [ENERGY_CONSUMPTION]
 ASSET_GROUPS_DEFINED_BY_OUTFLUX = [ENERGY_CONVERSION, ENERGY_PRODUCTION]
 
 
-def cut_below_pico(value, label):
+def cut_below_micro(value, label):
     r"""
     Function trims results of oemof optimization to positive values and rounds to 0, if within a certain precision threshold (of -10^-6)
 
@@ -101,16 +101,16 @@ def cut_below_pico(value, label):
     -----
 
     Tested with:
-    - E1.test_cut_below_pico_scalar_value_below_0_larger_threshold
-    - E1.test_cut_below_pico_scalar_value_below_0_smaller_threshold
-    - E1.test_cut_below_pico_scalar_value_0
-    - E1.test_cut_below_pico_scalar_value_larger_0
-    - E1.test_cut_below_pico_scalar_value_larger_0_smaller_threshold
-    - E1.test_cut_below_pico_pd_Series_below_0_larger_threshold
-    - E1.test_cut_below_pico_pd_Series_below_0_smaller_threshold
-    - E1.test_cut_below_pico_pd_Series_0
-    - E1.test_cut_below_pico_pd_Series_larger_0
-    - E1.test_cut_below_pico_pd_Series_larger_0_smaller_threshold
+    - E1.test_cut_below_micro_scalar_value_below_0_larger_threshold
+    - E1.test_cut_below_micro_scalar_value_below_0_smaller_threshold
+    - E1.test_cut_below_micro_scalar_value_0
+    - E1.test_cut_below_micro_scalar_value_larger_0
+    - E1.test_cut_below_micro_scalar_value_larger_0_smaller_threshold
+    - E1.test_cut_below_micro_pd_Series_below_0_larger_threshold
+    - E1.test_cut_below_micro_pd_Series_below_0_smaller_threshold
+    - E1.test_cut_below_micro_pd_Series_0
+    - E1.test_cut_below_micro_pd_Series_larger_0
+    - E1.test_cut_below_micro_pd_Series_larger_0_smaller_threshold
     """
     threshold = 10 ** (-6)
     text_block_start = f"The value of {label} is below 0"
@@ -277,13 +277,13 @@ def get_storage_results(settings, storage_bus, dict_asset):
     power_charge = storage_bus["sequences"][
         ((dict_asset[INFLOW_DIRECTION], dict_asset[LABEL]), "flow")
     ]
-    power_charge = cut_below_pico(power_charge, dict_asset[LABEL] + " charge flow")
+    power_charge = cut_below_micro(power_charge, dict_asset[LABEL] + " charge flow")
     add_info_flows(settings, dict_asset[INPUT_POWER], power_charge)
 
     power_discharge = storage_bus["sequences"][
         ((dict_asset[LABEL], dict_asset[OUTFLOW_DIRECTION]), "flow")
     ]
-    power_discharge = cut_below_pico(
+    power_discharge = cut_below_micro(
         power_discharge, dict_asset[LABEL] + " discharge flow"
     )
 
@@ -292,7 +292,7 @@ def get_storage_results(settings, storage_bus, dict_asset):
     capacity = storage_bus["sequences"][
         ((dict_asset[LABEL], TYPE_NONE), "storage_content")
     ]
-    capacity = cut_below_pico(capacity, dict_asset[LABEL] + " storage capacity")
+    capacity = cut_below_micro(capacity, dict_asset[LABEL] + " storage capacity")
 
     add_info_flows(settings, dict_asset[STORAGE_CAPACITY], capacity)
 
@@ -577,7 +577,7 @@ def get_optimal_cap(bus, dict_asset, flow_tuple):
             and (flow_tuple, "invest") in bus["scalars"]
         ):
             optimal_capacity = bus["scalars"][(flow_tuple, "invest")]
-            optimal_capacity = cut_below_pico(optimal_capacity, dict_asset[LABEL])
+            optimal_capacity = cut_below_micro(optimal_capacity, dict_asset[LABEL])
             if TIMESERIES_PEAK in dict_asset:
                 if dict_asset[TIMESERIES_PEAK][VALUE] > 0:
                     dict_asset.update(
@@ -646,7 +646,7 @@ def get_flow(settings, bus, dict_asset, flow_tuple):
 
     """
     flow = bus["sequences"][(flow_tuple, "flow")]
-    cut_below_pico(flow, dict_asset[LABEL] + " flow")
+    cut_below_micro(flow, dict_asset[LABEL] + " flow")
     add_info_flows(settings, dict_asset, flow)
 
     logging.debug(

--- a/src/multi_vector_simulator/E1_process_results.py
+++ b/src/multi_vector_simulator/E1_process_results.py
@@ -114,7 +114,7 @@ def cut_below_micro(value, label):
     """
     threshold = 10 ** (-6)
     text_block_start = f"The value of {label} is below 0"
-    text_block_set_0 = f"Negative value (s) are smaller then {-threshold}. This is likely a result of the termination/precision settings of the cbc solver. As the difference is marginal, the value will be set to 0. "
+    text_block_set_0 = f"Negative value (s) are smaller than {-threshold}. This is likely a result of the termination/precision settings of the cbc solver. As the difference is marginal, the value will be set to 0. "
     text_block_oemof = "This is so far below 0, that the value is not changed. All oemof decision variables should be positive so this needs to be investigated. "
 
     # flows

--- a/src/multi_vector_simulator/E1_process_results.py
+++ b/src/multi_vector_simulator/E1_process_results.py
@@ -101,20 +101,20 @@ def cut_below_pico(value, label):
     -----
 
     Tested with:
-    - E1.test_cut_below_pico_scalar_value_below_0_larger_treshhold
-    - E1.test_cut_below_pico_scalar_value_below_0_smaller_treshhold
+    - E1.test_cut_below_pico_scalar_value_below_0_larger_threshold
+    - E1.test_cut_below_pico_scalar_value_below_0_smaller_threshold
     - E1.test_cut_below_pico_scalar_value_0
     - E1.test_cut_below_pico_scalar_value_larger_0
     - E1.test_cut_below_pico_scalar_value_larger_0_smaller_threshold
-    - E1.test_cut_below_pico_pd_Series_below_0_larger_treshhold
-    - E1.test_cut_below_pico_pd_Series_below_0_smaller_treshhold
+    - E1.test_cut_below_pico_pd_Series_below_0_larger_threshold
+    - E1.test_cut_below_pico_pd_Series_below_0_smaller_threshold
     - E1.test_cut_below_pico_pd_Series_0
     - E1.test_cut_below_pico_pd_Series_larger_0
-    - E1.test_cut_below_pico_pd_Series_larger_0_smaller_treshold
+    - E1.test_cut_below_pico_pd_Series_larger_0_smaller_threshold
     """
-    treshhold = 10 ** (-6)
+    threshold = 10 ** (-6)
     text_block_start = f"The value of {label} is below 0"
-    text_block_set_0 = f"Negative value (s) are smaller then {-treshhold}. This is likely a result of the termination/precision settings of the cbc solver. As the difference is marginal, the value will be set to 0. "
+    text_block_set_0 = f"Negative value (s) are smaller then {-threshold}. This is likely a result of the termination/precision settings of the cbc solver. As the difference is marginal, the value will be set to 0. "
     text_block_oemof = "This is so far below 0, that the value is not changed. All oemof decision variables should be positive so this needs to be investigated. "
 
     # flows
@@ -126,24 +126,24 @@ def cut_below_pico(value, label):
             if isinstance(value, pd.Series):
                 instances = sum(value < 0)
                 log_msg += f" in {instances} instances. "
-            # Checks that all values are at least within the treshhold for negative values.
-            if (value > -treshhold).all():
+            # Checks that all values are at least within the threshold for negative values.
+            if (value > -threshold).all():
                 log_msg += text_block_set_0
                 logging.debug(log_msg)
                 value = value.clip(lower=0)
-            # If any value has a large negative value (lower then threshhold), no values are changed.
+            # If any value has a large negative value (lower then threshold), no values are changed.
             else:
-                test = value.clip(upper=-treshhold).abs()
-                log_msg += f"At least one value is exceeds the scale of {-treshhold}. The highest negative value is -{max(test)}. "
+                test = value.clip(upper=-threshold).abs()
+                log_msg += f"At least one value is exceeds the scale of {-threshold}. The highest negative value is -{max(test)}. "
                 log_msg += text_block_oemof
                 logging.warning(log_msg)
 
         # Determine if there are any positive values that are between 0 and the threshold:
         # Clip to interval
-        positive_threshold = value.clip(lower=0, upper=treshhold)
-        # Determine instances in which bounds are met: 1=either 0 or larger threshold, 0=smaller treshold
+        positive_threshold = value.clip(lower=0, upper=threshold)
+        # Determine instances in which bounds are met: 1=either 0 or larger threshold, 0=smaller threshold
         positive_threshold = (positive_threshold == 0) + (
-            positive_threshold == treshhold
+            positive_threshold == threshold
         )
         # Instances in which values are in determined interval:
         instances = len(value) - sum(positive_threshold)
@@ -151,7 +151,7 @@ def cut_below_pico(value, label):
             logging.debug(
                 f"There are {instances} instances in which there are positive values smaller then the threshold."
             )
-            # Multiply with positive_threshold (1=either 0 or larger threshold, 0=smaller treshold)
+            # Multiply with positive_threshold (1=either 0 or larger threshold, 0=smaller threshold)
             value = value * positive_threshold
 
     # capacities
@@ -160,19 +160,19 @@ def cut_below_pico(value, label):
         if value < 0:
             log_msg = text_block_start
             # Value between [threshold, 0] = [-10**(-6)], ie. is so small that it can be neglected.
-            if value > -treshhold:
+            if value > -threshold:
                 log_msg += text_block_set_0
                 logging.debug(log_msg)
                 value = 0
             # Value is below 0 but already large enough that it should not be neglected.
             else:
-                log_msg += f"The value exceeds the scale of {-treshhold}, with {value}."
+                log_msg += f"The value exceeds the scale of {-threshold}, with {value}."
                 log_msg += text_block_oemof
                 logging.warning(log_msg)
         # Value is above 0 but below threshold, should be rounded
-        elif value < treshhold:
+        elif value < threshold:
             logging.debug(
-                f"The positive value {value} is below the {treshhold}, and rounded to 0."
+                f"The positive value {value} is below the {threshold}, and rounded to 0."
             )
             value = 0
 

--- a/tests/test_E1_process_results.py
+++ b/tests/test_E1_process_results.py
@@ -306,7 +306,7 @@ def test_cut_below_pico_pd_Series_larger_0_smaller_treshold(caplog):
     ).all(), f"One value in pd.Series is below 0 but smaller then the threshold, its value should be changed to zero (but it is {result})."
 
 
-
+"""
 def test_get_optimal_cap_optimize_input_flow_timeseries_peak_provided():
     pass
 
@@ -354,4 +354,4 @@ def test_get_optimal_cap_optimizeCap_not_in_dict_asset():
 # def test_get_flow_invalid_direction_raises_value_error():
 #     pass
 # same tests as add_info_flow() just that bus and direction is provided.
-
+"""

--- a/tests/test_E1_process_results.py
+++ b/tests/test_E1_process_results.py
@@ -191,25 +191,25 @@ def test_get_tuple_for_oemof_results():
         assert flux_tuple == (asset_label, bus)
 
 
-def test_cut_below_pico_scalar_value_below_0_larger_treshhold(caplog):
+def test_cut_below_pico_scalar_value_below_0_larger_threshold(caplog):
     value = -1
     with caplog.at_level(logging.WARNING):
         result = E1.cut_below_pico(value=value, label="label")
     assert (
         "This is so far below 0, that the value is not changed" in caplog.text
-    ), f"The value {value} is below 0 and larger then the treshhold, but no warning is displayed that this value may be invalid."
+    ), f"The value {value} is below 0 and larger then the threshold, but no warning is displayed that this value may be invalid."
     assert (
         result == value
     ), f"As value {value} is below 0 but larger then the threshold, its value should not be changed (but it is {result})."
 
 
-def test_cut_below_pico_scalar_value_below_0_smaller_treshhold(caplog):
+def test_cut_below_pico_scalar_value_below_0_smaller_threshold(caplog):
     value = -0.5 * 10 ** (-6)
     with caplog.at_level(logging.DEBUG):
         result = E1.cut_below_pico(value=value, label="label")
     assert (
         "Negative value (s)" in caplog.text
-    ), f"The value {value} is below 0 and below the treshhold, but the log does not register a debug message for this."
+    ), f"The value {value} is below 0 and below the threshold, but the log does not register a debug message for this."
     assert (
         result == 0
     ), f"As value {value} is below 0 but smaller then the threshold, its value should be changed to zero (but it is {result})."
@@ -237,33 +237,33 @@ def test_cut_below_pico_scalar_value_larger_0_smaller_threshold(caplog):
         result = E1.cut_below_pico(value=value, label="label")
     assert (
         "The positive value" in caplog.text
-    ), f"The value {value} is larger 0 but below the treshold and should raise a debug message."
+    ), f"The value {value} is larger 0 but below the threshold and should raise a debug message."
 
     assert (
         result == 0
     ), f"As value {value} positive but smaller then the threshold, its value should be changed to zero (but it is {result})."
 
 
-def test_cut_below_pico_pd_Series_below_0_larger_treshhold(caplog):
+def test_cut_below_pico_pd_Series_below_0_larger_threshold(caplog):
     value = pd.Series([0, -0.5 * 10 ** (-6), -1, 0])
     with caplog.at_level(logging.WARNING):
         result = E1.cut_below_pico(value=value, label="label")
     assert (
         "This is so far below 0, that the value is not changed" in caplog.text
-    ), f"One value in pd.Series is below 0 and larger then the treshhold, but no warning is displayed that this value may be invalid."
+    ), f"One value in pd.Series is below 0 and larger then the threshold, but no warning is displayed that this value may be invalid."
     assert (
         result == value
     ).all(), f"As value {value} is below 0 but larger then the threshold, its value should not be changed (but it is {result})."
 
 
-def test_cut_below_pico_pd_Series_below_0_smaller_treshhold(caplog):
+def test_cut_below_pico_pd_Series_below_0_smaller_threshold(caplog):
     value = pd.Series([0, -0.5 * 10 ** (-6), 0, 1])
     exp = pd.Series([0, 0, 0, 1])
     with caplog.at_level(logging.DEBUG):
         result = E1.cut_below_pico(value=value, label="label")
     assert (
         "Negative value (s)" in caplog.text
-    ), f"One value in pd.Series is below 0 and below the treshhold, but the log does not register a debug message for this."
+    ), f"One value in pd.Series is below 0 and below the threshold, but the log does not register a debug message for this."
     assert (
         result[1] == 0
     ), f"As value {value[1]} is below 0 but smaller then the threshold, its value should be changed to zero (but it is {result[1]})."
@@ -290,14 +290,14 @@ def test_cut_below_pico_pd_Series_larger_0():
     ).all(), f"All values in pd.Series are larger 0 and therefore should not be changed (but it is {result})."
 
 
-def test_cut_below_pico_pd_Series_larger_0_smaller_treshold(caplog):
+def test_cut_below_pico_pd_Series_larger_0_smaller_threshold(caplog):
     value = pd.Series([0, 0.5 * 10 ** (-6), 0, 1])
     exp = pd.Series([0, 0, 0, 1])
     with caplog.at_level(logging.DEBUG):
         result = E1.cut_below_pico(value=value, label="label")
     assert (
         " positive values smaller then the threshold" in caplog.text
-    ), f"One value in pd.Series is above 0 and below the treshhold, but the log does not register a debug message for this."
+    ), f"One value in pd.Series is above 0 and below the threshold, but the log does not register a debug message for this."
     assert (
         result[1] == 0
     ), f"As value {value[1]} is below 0 but smaller then the threshold, its value should be changed to zero (but it is {result[1]})."

--- a/tests/test_E1_process_results.py
+++ b/tests/test_E1_process_results.py
@@ -191,10 +191,10 @@ def test_get_tuple_for_oemof_results():
         assert flux_tuple == (asset_label, bus)
 
 
-def test_cut_below_pico_scalar_value_below_0_larger_threshold(caplog):
+def test_cut_below_micro_scalar_value_below_0_larger_threshold(caplog):
     value = -1
     with caplog.at_level(logging.WARNING):
-        result = E1.cut_below_pico(value=value, label="label")
+        result = E1.cut_below_micro(value=value, label="label")
     assert (
         "This is so far below 0, that the value is not changed" in caplog.text
     ), f"The value {value} is below 0 and larger then the threshold, but no warning is displayed that this value may be invalid."
@@ -203,10 +203,10 @@ def test_cut_below_pico_scalar_value_below_0_larger_threshold(caplog):
     ), f"As value {value} is below 0 but larger then the threshold, its value should not be changed (but it is {result})."
 
 
-def test_cut_below_pico_scalar_value_below_0_smaller_threshold(caplog):
-    value = -0.5 * 10 ** (-6)
+def test_cut_below_micro_scalar_value_below_0_smaller_threshold(caplog):
+    value = -0.5 * 1e-6
     with caplog.at_level(logging.DEBUG):
-        result = E1.cut_below_pico(value=value, label="label")
+        result = E1.cut_below_micro(value=value, label="label")
     assert (
         "Negative value (s)" in caplog.text
     ), f"The value {value} is below 0 and below the threshold, but the log does not register a debug message for this."
@@ -215,26 +215,26 @@ def test_cut_below_pico_scalar_value_below_0_smaller_threshold(caplog):
     ), f"As value {value} is below 0 but smaller then the threshold, its value should be changed to zero (but it is {result})."
 
 
-def test_cut_below_pico_scalar_value_0():
+def test_cut_below_micro_scalar_value_0():
     value = 0
-    result = E1.cut_below_pico(value=value, label="label")
+    result = E1.cut_below_micro(value=value, label="label")
     assert (
         result == value
     ), f"The value {value} is 0 and should not be changed (but it is {result})."
 
 
-def test_cut_below_pico_scalar_value_larger_0():
+def test_cut_below_micro_scalar_value_larger_0():
     value = 1
-    result = E1.cut_below_pico(value=value, label="label")
+    result = E1.cut_below_micro(value=value, label="label")
     assert (
         result == value
-    ), f"The value {value} is larger 0 and therefore should not be changed (but it is {result})."
+    ), f"The value {value} is larger 0 by more than the threshold and therefore should not be changed (but it is {result})."
 
 
-def test_cut_below_pico_scalar_value_larger_0_smaller_threshold(caplog):
-    value = 0.5 * 10 ** (-6)
+def test_cut_below_micro_scalar_value_larger_0_smaller_threshold(caplog):
+    value = 0.5 * 1e-6
     with caplog.at_level(logging.DEBUG):
-        result = E1.cut_below_pico(value=value, label="label")
+        result = E1.cut_below_micro(value=value, label="label")
     assert (
         "The positive value" in caplog.text
     ), f"The value {value} is larger 0 but below the threshold and should raise a debug message."
@@ -244,10 +244,10 @@ def test_cut_below_pico_scalar_value_larger_0_smaller_threshold(caplog):
     ), f"As value {value} positive but smaller then the threshold, its value should be changed to zero (but it is {result})."
 
 
-def test_cut_below_pico_pd_Series_below_0_larger_threshold(caplog):
-    value = pd.Series([0, -0.5 * 10 ** (-6), -1, 0])
+def test_cut_below_micro_pd_Series_below_0_larger_threshold(caplog):
+    value = pd.Series([0, -0.5 * 1e-6, -1, 0])
     with caplog.at_level(logging.WARNING):
-        result = E1.cut_below_pico(value=value, label="label")
+        result = E1.cut_below_micro(value=value, label="label")
     assert (
         "This is so far below 0, that the value is not changed" in caplog.text
     ), f"One value in pd.Series is below 0 and larger then the threshold, but no warning is displayed that this value may be invalid."
@@ -256,11 +256,11 @@ def test_cut_below_pico_pd_Series_below_0_larger_threshold(caplog):
     ).all(), f"As value {value} is below 0 but larger then the threshold, its value should not be changed (but it is {result})."
 
 
-def test_cut_below_pico_pd_Series_below_0_smaller_threshold(caplog):
-    value = pd.Series([0, -0.5 * 10 ** (-6), 0, 1])
+def test_cut_below_micro_pd_Series_below_0_smaller_threshold(caplog):
+    value = pd.Series([0, -0.5 * 1e-6, 0, 1])
     exp = pd.Series([0, 0, 0, 1])
     with caplog.at_level(logging.DEBUG):
-        result = E1.cut_below_pico(value=value, label="label")
+        result = E1.cut_below_micro(value=value, label="label")
     assert (
         "Negative value (s)" in caplog.text
     ), f"One value in pd.Series is below 0 and below the threshold, but the log does not register a debug message for this."
@@ -272,9 +272,9 @@ def test_cut_below_pico_pd_Series_below_0_smaller_threshold(caplog):
     ).all(), f"One value in pd.Series is below 0 but smaller then the threshold, its value should be changed to zero (but it is {result})."
 
 
-def test_cut_below_pico_pd_Series_0():
+def test_cut_below_micro_pd_Series_0():
     value = pd.Series([0, 0, 0, 1])
-    result = E1.cut_below_pico(value=value, label="label")
+    result = E1.cut_below_micro(value=value, label="label")
     assert (
         result == value
     ).all(), (
@@ -282,19 +282,19 @@ def test_cut_below_pico_pd_Series_0():
     )
 
 
-def test_cut_below_pico_pd_Series_larger_0():
+def test_cut_below_micro_pd_Series_larger_0():
     value = pd.Series([1, 2, 3, 4])
-    result = E1.cut_below_pico(value=value, label="label")
+    result = E1.cut_below_micro(value=value, label="label")
     assert (
         result == value
-    ).all(), f"All values in pd.Series are larger 0 and therefore should not be changed (but it is {result})."
+    ).all(), f"All values in pd.Series are larger 0 by more than the threshold and therefore should not be changed (but it is {result})."
 
 
-def test_cut_below_pico_pd_Series_larger_0_smaller_threshold(caplog):
-    value = pd.Series([0, 0.5 * 10 ** (-6), 0, 1])
+def test_cut_below_micro_pd_Series_larger_0_smaller_threshold(caplog):
+    value = pd.Series([0, 0.5 * 1e-6, 0, 1])
     exp = pd.Series([0, 0, 0, 1])
     with caplog.at_level(logging.DEBUG):
-        result = E1.cut_below_pico(value=value, label="label")
+        result = E1.cut_below_micro(value=value, label="label")
     assert (
         " positive values smaller then the threshold" in caplog.text
     ), f"One value in pd.Series is above 0 and below the threshold, but the log does not register a debug message for this."

--- a/tests/test_E4_verification.py
+++ b/tests/test_E4_verification.py
@@ -84,7 +84,7 @@ def test_maximum_emissions_test_passes():
     # Total emissions > maximum emissions constraint, minimal diff
     dict_values = {
         CONSTRAINTS: {MAXIMUM_EMISSIONS: {VALUE: 1000}},
-        KPI: {KPI_SCALARS_DICT: {TOTAL_EMISSIONS: 1000 + 10 ** (-6)}},
+        KPI: {KPI_SCALARS_DICT: {TOTAL_EMISSIONS: 1000 + 1e-6}},
     }
     return_value = E4.maximum_emissions_test(dict_values)
     assert (


### PR DESCRIPTION
Fix #523
Fix #768

We had issues with the SOC being out of bounds with [0,1] and marginal negative flows. This PR fixes both issues. The marginal negative flows are rounded to 0 (threshold: -10^-6), large negative values raise a warning and are unchanged. Marginal positive flows (reason for SOC out of bounds) are also rounded to 0.

Compared to SOC in #768, you can see that in the now created [simulation_report.pdf](https://github.com/rl-institut/multi-vector-simulator/files/5945489/simulation_report.pdf) the SOC is always 0.

**Changes proposed in this pull request**:
[x] Add precision issue in RTD
[x] Function `E1.cut_below_pico` to round decision variables (capacities, flows) below threshold of plus/minus 10^-6 to 0, add warnings if negative value larger then threshold (invalid result). Includes pytests (#)
[x] Call `E1.cut_below_pico` in `E1.get_flows`, `E1.get_optimal_cap` and `E1.get_storage_results` (#) 

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [x] For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)