### PR TITLE
[RTD] Adapt structure of component models section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,9 @@ Here is a template for new release sections
 - Minimal degree of autonomy constraint including pytest and benchmark test (#726)
 - Add benchmark test for json benchmark file from EPA (EPA-MVS compatability) (#781)
 - Add a try-except code block to catch fatal errors that cause simulation to terminate unsuccessfully (#754)
-
 - The parameters `fixed_losses_relative` and `fixed_losses_absolute` were added. It is now possible to model a stratified thermal energy storage. The usage of this new component has been tested and documented (#718)
 - It is now possible to model a stratified thermal energy storage. In this context, the two optional parameters `fixed_losses_relative` and `fixed_losses_absolute` were added and can be set in the `storage_*.csv` file. The usage of this new component was tested in `test_A1_csv_to_json.py`, `test_D1_model_components.py` and `test_benchmark_stratified_thermal_storage.py`. A documentation was added in the chapter `Modeling Assumptions of the MVS` (#718)
-
+- Added a note in Energy excess section in RTD (component models) saying that excess sinks are added automatically (#792)
 
 ### Changed
 - Fix xlrd to xlrd==1.2.0 in requirements/default.txt (#716)
@@ -64,6 +63,7 @@ Here is a template for new release sections
 - In `test_A1_csv_to_json.py` tests were added that check whether default values of `0` are set for `fixed_losses_relative` and `fixed_losses_absolute` in case the user does not pass these two parameters (#718)
 - In `test_D1_model_components.py` tests were added that check whether the `GenericStorage` parameter `investment.minimum` is set to `0` in case `fixed_losses_relative` and `fixed_losses_absolute` are not passed and to `1` in case they are passed as times series or floats. At this time it is not possible to do an ivestment optimization of a stratified thermal energy storage without a non-zero `investment.minimum` (see this [issue](https://github.com/oemof/oemof-thermal/issues/174))  (#718)
 - The two optional parameters `fixed_losses_relative` and `fixed_losses_absolute` were added in `tests/inputs/mvs_config.json` (#718)
+- Adapted structure of component models in RTD to mirror EPA and MVS input data (#792)
 
 ### Removed
 - Remove `MissingParameterWarning` and use `logging.warning` instead (#761)

--- a/docs/Model_Assumptions.rst
+++ b/docs/Model_Assumptions.rst
@@ -36,10 +36,10 @@ Dispatchable sources of generation
 Fuel sources are added as dispatchable sources, which still can have development, investment, operational and dispatch costs.
 They are added by adding a column in `energyProviders.CSV`, and setting file_name to `None`.
 
-DSOs, even though also dispatchable sources of generation, should be added via `energyProviders.csv`,
+Energy providers, even though also dispatchable sources of generation, should be added via `energyProviders.csv`,
 as there are some additional features available then.
 
-Both DSOs and the additional fuel sources are limited to the options provided in the table of :ref:`table_default_energy_carrier_weights_label`, as the default weighting factors to translate the energy carrier into electricity equivalent need to be defined.
+Both energy providers and the additional fuel sources are limited to the options provided in the table of :ref:`table_default_energy_carrier_weights_label`, as the default weighting factors to translate the energy carrier into electricity equivalent need to be defined.
 
 
 Energy conversion
@@ -66,10 +66,10 @@ The energy providers are the most complex assets in the MVS model. They are comp
     - Energy consumption source, providing the energy required from the system with a certain price
     - Energy peak demand pricing "transformers", which represent the costs induced due to peak demand
     - Bus connecting energy consumption source and energy peak demand pricing transformers
-    - Energy feed-in sink, able to take in generation that is provided to the DSO for revenue
-    - Optionally: Transformer Station connecting the DSO bus to the energy bus of the LES
+    - Energy feed-in sink, able to take in generation that is provided to the energy provider for revenue
+    - Optionally: Transformer Station connecting the energy provider bus to the energy bus of the LES
 
-With all these components, the DSO can be visualized as follows:
+With all these components, the energy provider can be visualized as follows:
 
 .. image:: images/Model_Assumptions_energyProvider_assets.png
  :width: 600
@@ -84,7 +84,7 @@ Peak demand pricing
 
 A peak demand pricing scheme is based on an electricity tariff,
 that requires the consumer not only to pay for the aggregated energy consumption in a time period (eg. kWh electricity),
-but also for the maximum peak demand (load, eg. kW power) towards the DSO grid within a specific pricing period.
+but also for the maximum peak demand (load, eg. kW power) towards the grid of the energy provider within a specific pricing period.
 
 In the MVS, this information is gathered for the `energyProviders` with:
 

--- a/docs/Model_Assumptions.rst
+++ b/docs/Model_Assumptions.rst
@@ -12,8 +12,12 @@ This is the reason that the MVS can provide a pre-feasibility study of a specifi
 but not the final sizing and system design.
 The types of assets are presented below.
 
+
+Energy Production
+#################
+
 Non-dispatchable sources of generation
-######################################
+======================================
 
 `Examples`:
 
@@ -21,7 +25,7 @@ Non-dispatchable sources of generation
     - Wind plant
 
 Dispatchable sources of generation
-##################################
+==================================
 
 `Examples`:
 
@@ -37,8 +41,9 @@ as there are some additional features available then.
 
 Both DSOs and the additional fuel sources are limited to the options provided in the table of :ref:`table_default_energy_carrier_weights_label`, as the default weighting factors to translate the energy carrier into electricity equivalent need to be defined.
 
-Dispatchable conversion assets
-##############################
+
+Energy conversion
+#################
 
 `Examples`:
 
@@ -52,19 +57,50 @@ The parameters `dispatch_price`, `efficiency` and `installedCap` of transformers
 This means that these parameters need to be given for the electrical output power in case of a diesel generator (more examples: electrolyzer - H2, heat pumps and boiler - nominal heat ouput, inverters / rectifiers - electrical output power).
 This also means that the costs of the fuel of a diesel generator (input flow) are not included in its `dispatch_price` but in the `dispatch_price` of the fuel source.
 
-Energy excess
-#############
 
-An energy excess sink is placed on each of the LES energy busses, and therefore energy excess is allowed to take place on each bus of the LES.
-This means that there are assumed to be sufficient vents (heat) or transistors (electricity) to dump excess (waste) generation.
-Excess generation can only take place when a non-dispatchable source is present or if an asset can supply energy without any fuel or dispatch costs.
+Energy providers (DSOs)
+#######################
 
-In case of excessive excess energy, a warning is given that it seems to be cheaper to have high excess generation than investing into more capacities.
-High excess energy can for example result into an optimized inverter capacity that is smaller than the peak generation of installed PV.
-This becomes unrealistic when the excess is very high.
+The energy providers are the most complex assets in the MVS model. They are composed of a number of sub-assets
+
+    - Energy consumption source, providing the energy required from the system with a certain price
+    - Energy peak demand pricing "transformers", which represent the costs induced due to peak demand
+    - Bus connecting energy consumption source and energy peak demand pricing transformers
+    - Energy feed-in sink, able to take in generation that is provided to the DSO for revenue
+    - Optionally: Transformer Station connecting the DSO bus to the energy bus of the LES
+
+With all these components, the DSO can be visualized as follows:
+
+.. image:: images/Model_Assumptions_energyProvider_assets.png
+ :width: 600
+
+Variable energy consumption prices (time-series)
+================================================
+
+- Link to howto
+
+Peak demand pricing
+===================
+
+A peak demand pricing scheme is based on an electricity tariff,
+that requires the consumer not only to pay for the aggregated energy consumption in a time period (eg. kWh electricity),
+but also for the maximum peak demand (load, eg. kW power) towards the DSO grid within a specific pricing period.
+
+In the MVS, this information is gathered for the `energyProviders` with:
+
+    - :const:`multi_vector_simulator.utils.constants_json_strings.PEAK_DEMAND_PRICING_PERIOD` as the period used in peak demand pricing. Possible is 1 (yearly), 2 (half-yearly), 3 (each trimester), 4 (quaterly), 6 (every 2 months) and 12 (each month). If you have a `simulation_duration` < 365 days, the periods will still be set up assuming a year! This means, that if you are simulating 14 days, you will never be able to have more than one peak demand pricing period in place.
+
+    - :const:`multi_vector_simulator.utils.constants_json_strings.PEAK_DEMAND_PRICING` as the costs per peak load unit, eg. kW
+
+To represent the peak demand pricing, the MVS adds a "transformer" that is optimized with specific operation and maintenance costs per year equal to the PEAK_DEMAND_PRICING for each of the pricing periods.
+For two peak demand pricing periods, the resulting dispatch could look as following:
+
+.. image:: images/Model_Assumptions_Peak_Demand_Pricing_Dispatch_Graph.png
+ :width: 600
+
 
 Energy storage
-###########
+##############
 
 Generic storages are defined with file `energyStorage.csv` and `storage_*.csv` and have subassets, which are listed in :ref:`storage_csv`.
 
@@ -122,45 +158,18 @@ For an investment optimization the height of the storage should be left open in 
 
 An implementation of the stratified thermal storage component has been done in `pvcompare <https://github.com/greco-project/pvcompare>`__. You can find the precalculations of the stratified thermal energy storage made in `pvcompare` `here <https://github.com/greco-project/pvcompare/tree/dev/pvcompare/stratified_thermal_storage.py>`__.
 
-Energy providers (DSOs)
------------------------
 
-The energy providers are the most complex assets in the MVS model. They are composed of a number of sub-assets
+Energy excess
+#############
 
-    - Energy consumption source, providing the energy required from the system with a certain price
-    - Energy peak demand pricing "transformers", which represent the costs induced due to peak demand
-    - Bus connecting energy consumption source and energy peak demand pricing transformers
-    - Energy feed-in sink, able to take in generation that is provided to the DSO for revenue
-    - Optionally: Transformer Station connecting the DSO bus to the energy bus of the LES
+An energy excess sink is placed on each of the LES energy busses, and therefore energy excess is allowed to take place on each bus of the LES.
+This means that there are assumed to be sufficient vents (heat) or transistors (electricity) to dump excess (waste) generation.
+Excess generation can only take place when a non-dispatchable source is present or if an asset can supply energy without any fuel or dispatch costs.
 
-With all these components, the DSO can be visualized as follows:
+In case of excessive excess energy, a warning is given that it seems to be cheaper to have high excess generation than investing into more capacities.
+High excess energy can for example result into an optimized inverter capacity that is smaller than the peak generation of installed PV.
+This becomes unrealistic when the excess is very high.
 
-.. image:: images/Model_Assumptions_energyProvider_assets.png
- :width: 600
-
-Variable energy consumption prices (time-series)
-################################################
-
-- Link to howto
-
-Peak demand pricing
-###################
-
-A peak demand pricing scheme is based on an electricity tariff,
-that requires the consumer not only to pay for the aggregated energy consumption in a time period (eg. kWh electricity),
-but also for the maximum peak demand (load, eg. kW power) towards the DSO grid within a specific pricing period.
-
-In the MVS, this information is gathered for the `energyProviders` with:
-
-    - :const:`multi_vector_simulator.utils.constants_json_strings.PEAK_DEMAND_PRICING_PERIOD` as the period used in peak demand pricing. Possible is 1 (yearly), 2 (half-yearly), 3 (each trimester), 4 (quaterly), 6 (every 2 months) and 12 (each month). If you have a `simulation_duration` < 365 days, the periods will still be set up assuming a year! This means, that if you are simulating 14 days, you will never be able to have more than one peak demand pricing period in place.
-
-    - :const:`multi_vector_simulator.utils.constants_json_strings.PEAK_DEMAND_PRICING` as the costs per peak load unit, eg. kW
-
-To represent the peak demand pricing, the MVS adds a "transformer" that is optimized with specific operation and maintenance costs per year equal to the PEAK_DEMAND_PRICING for each of the pricing periods.
-For two peak demand pricing periods, the resulting dispatch could look as following:
-
-.. image:: images/Model_Assumptions_Peak_Demand_Pricing_Dispatch_Graph.png
- :width: 600
 
 Constraints
 -----------

--- a/docs/Model_Assumptions.rst
+++ b/docs/Model_Assumptions.rst
@@ -58,7 +58,7 @@ This means that these parameters need to be given for the electrical output powe
 This also means that the costs of the fuel of a diesel generator (input flow) are not included in its `dispatch_price` but in the `dispatch_price` of the fuel source.
 
 
-Energy providers (DSOs)
+Energy providers
 #######################
 
 The energy providers are the most complex assets in the MVS model. They are composed of a number of sub-assets

--- a/docs/Model_Assumptions.rst
+++ b/docs/Model_Assumptions.rst
@@ -59,7 +59,7 @@ This also means that the costs of the fuel of a diesel generator (input flow) ar
 
 
 Energy providers
-#######################
+################
 
 The energy providers are the most complex assets in the MVS model. They are composed of a number of sub-assets
 

--- a/docs/Model_Assumptions.rst
+++ b/docs/Model_Assumptions.rst
@@ -162,6 +162,9 @@ An implementation of the stratified thermal storage component has been done in `
 Energy excess
 #############
 
+.. note::
+   Energy excess components are implemented **automatically** by MVS! You do not need to define them yourself.
+
 An energy excess sink is placed on each of the LES energy busses, and therefore energy excess is allowed to take place on each bus of the LES.
 This means that there are assumed to be sufficient vents (heat) or transistors (electricity) to dump excess (waste) generation.
 Excess generation can only take place when a non-dispatchable source is present or if an asset can supply energy without any fuel or dispatch costs.


### PR DESCRIPTION
Adress #779

**Changes proposed in this pull request**:
- Adapted structure of component models in RTD to mirror EPA and MVS input data
- Added a note in Energy excess section in RTD (component models) saying that excess sinks are added automatically

The following steps were realized, as well (if applies):
:x: Use in-line comments to explain your code
:x: Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
:x: For new functionalities: Explain in readthedocs
:x: Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
:x: Apply black (`black . --exclude docs/`)
:x: Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
