### PR TITLE
Fix data parser logging typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Here is a template for new release sections
 - Fix `numpy.int32` error in `B0` (#778)
 - `mvs_config.json` is generated again, now from `cli.py` (#783)
 - Fix pytest `C1.test_check_non_dispatchable_source_time_series_passes` and `C1.test_check_non_dispatchable_source_time_series_results_in_error_msg` (#783)
+- Fix typo in `utils.data_parser.convert_epa_params_to_mvs()` (#808)
 
 ## [0.5.4] - 2020-12-18
 

--- a/src/multi_vector_simulator/utils/data_parser.py
+++ b/src/multi_vector_simulator/utils/data_parser.py
@@ -430,7 +430,7 @@ def convert_epa_params_to_mvs(epa_dict):
 
             dict_values[asset_group] = dict_asset
         else:
-            logging.INFO(
+            logging.info(
                 f"The assets parameters '{MAP_MVS_EPA[asset_group]}' is not present in the EPA parameters to be parsed into MVS json format"
             )
 


### PR DESCRIPTION
Fix `logging.info` message for data parser from EPA to MVS, as identified in https://github.com/rl-institut/mvs_eland_api/issues/10