### PR TITLE
Fix data parser logging typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Here is a template for new release sections
 - Fix `numpy.int32` error in `B0` (#778)
 - `mvs_config.json` is generated again, now from `cli.py` (#783)
 - Fix pytest `C1.test_check_non_dispatchable_source_time_series_passes` and `C1.test_check_non_dispatchable_source_time_series_results_in_error_msg` (#783)
+- Fix typo in `utils.data_parser` `logging.INFO` was used instead of `logging.info` (#809)
 
 ## [0.5.4] - 2020-12-18
 

--- a/src/multi_vector_simulator/utils/data_parser.py
+++ b/src/multi_vector_simulator/utils/data_parser.py
@@ -430,7 +430,7 @@ def convert_epa_params_to_mvs(epa_dict):
 
             dict_values[asset_group] = dict_asset
         else:
-            logging.INFO(
+            logging.info(
                 f"The assets parameters '{MAP_MVS_EPA[asset_group]}' is not present in the EPA parameters to be parsed into MVS json format"
             )
 

--- a/src/multi_vector_simulator/utils/data_parser.py
+++ b/src/multi_vector_simulator/utils/data_parser.py
@@ -12,6 +12,7 @@ This module defines all functions to convert formats between EPA and MVS
 import pprint
 import logging
 import json
+from copy import deepcopy
 
 from multi_vector_simulator.utils import compare_input_parameters_with_reference
 
@@ -264,6 +265,7 @@ def convert_epa_params_to_mvs(epa_dict):
 
     """
 
+    epa_dict = deepcopy(epa_dict)
     dict_values = {}
 
     for param_group in [

--- a/tests/test_E3_indicator_calculation.py
+++ b/tests/test_E3_indicator_calculation.py
@@ -723,7 +723,7 @@ def test_equation_degree_of_net_zero_energy_is_zero():
 
 def test_equation_degree_of_net_zero_energy_is_one():
     """ """
-    total_feedin =100
+    total_feedin = 100
     total_grid_consumption = 100
     total_demand = 100
     degree_of_nze = E3.equation_degree_of_net_zero_energy(
@@ -738,7 +738,7 @@ def test_equation_degree_of_net_zero_energy_is_one():
 
 def test_equation_degree_of_net_zero_energy_greater_one():
     """ """
-    total_feedin =150
+    total_feedin = 150
     total_grid_consumption = 100
     total_demand = 100
     degree_of_nze = E3.equation_degree_of_net_zero_energy(


### PR DESCRIPTION

**Changes proposed in this pull request**:
- Fix logging.info message for data parser from EPA to MVS, as identified in rl-institut/mvs_eland_api#10
- Use deepcopy with dict passed to EPA/MVS parser

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
