### PR TITLE
mvs_report from json_with_results

### DIFF
--- a/src/multi_vector_simulator/B0_data_input_json.py
+++ b/src/multi_vector_simulator/B0_data_input_json.py
@@ -336,4 +336,13 @@ def load_json(
         dict_values, flag_missing=flag_missing_values, set_default=set_default_values
     )
 
+     if KPI in dict_values:
+        for kpi in (KPI_COST_MATRIX, KPI_SCALAR_MATRIX):
+
+            if not isinstance(dict_values[KPI][kpi], pd.DataFrame):
+                dict_values[KPI][kpi] = pd.DataFrame.from_records(dict_values[KPI][kpi])
+
+            if LABEL not in dict_values[KPI][kpi].columns:
+                dict_values[KPI][kpi][LABEL] = dict_values[KPI][kpi].index
+                
     return dict_values

--- a/src/multi_vector_simulator/B0_data_input_json.py
+++ b/src/multi_vector_simulator/B0_data_input_json.py
@@ -26,6 +26,10 @@ from multi_vector_simulator.utils.constants_json_strings import (
     VALUE,
     DATA,
     TIMESERIES,
+    KPI,
+    KPI_COST_MATRIX,
+    KPI_SCALAR_MATRIX,
+    LABEL,
 )
 
 from multi_vector_simulator.utils.constants import (


### PR DESCRIPTION
Fix #813 

**Changes proposed in this pull request**:
- minor change to allow the user to run `mvs_report` with a single json_with_results file.

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [ ] Update the CHANGELOG.md
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
