### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,6 @@ jobs:
             sudo apt-get update
             sudo apt-get install coinor-cbc
             sudo apt-get install graphviz
-            sudo apt-get install wkhtmltopdf
 
       # Runs a set of commands using the runners shell
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,4 +64,5 @@ jobs:
 
       - name: Test with pytest
         run: |
-          coverage run -m pytest
+          coverage run -m pytest tests/ -k "not test_benchmark_kpi" --durations-min=1.0 --durations=400
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Here is a template for new release sections
 ### Removed
 -
 ### Fixed
-- Skip `test_benchmark_KPI` as it was seen to be consumming the whole test time leading to timeout on github action (#826)
+- Skip `test_benchmark_KPI` as it was seen to be consuming the whole test time leading to timeout on github action (#826)
 - Reduce `simulation_settings.evaluated_period` to one day for the tests where simulation results are not important (for E0 and D2 test modules setup) (#826)
 
 ## [0.5.5] - 2021-03-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ Here is a template for new release sections
 ### Removed
 -
 ### Fixed
--
+- Skip `test_benchmark_KPI` as it was seen to be consumming the whole test time leading to timeout on github action (#826)
+- Reduce `simulation_settings.evaluated_period` to one day for the tests where simulation results are not important (for E0 and D2 test modules setup) (#826)
 
 ## [0.5.5] - 2021-03-04
 

--- a/tests/test_D2_model_constraints.py
+++ b/tests/test_D2_model_constraints.py
@@ -41,6 +41,8 @@ from multi_vector_simulator.utils.constants_json_strings import (
     INFLOW_DIRECTION,
     DSO_FEEDIN,
     NET_ZERO_ENERGY,
+    EVALUATED_PERIOD,
+    SIMULATION_SETTINGS,
 )
 
 from multi_vector_simulator.utils.constants import OUTPUT_FOLDER
@@ -370,6 +372,9 @@ class TestConstraints:
                 path_output_folder=user_input[PATH_OUTPUT_FOLDER],
                 move_copy=False,
             )
+
+            dict_values[SIMULATION_SETTINGS][EVALUATED_PERIOD][VALUE] = 1
+
             logging.debug("Accessing script: C0_data_processing")
             C0.all(dict_values)
 

--- a/tests/test_E0_evaluation.py
+++ b/tests/test_E0_evaluation.py
@@ -53,6 +53,9 @@ def setup_module(m_args):
         path_output_folder=user_input[PATH_OUTPUT_FOLDER],
         move_copy=False,
     )
+
+    dict_values[SIMULATION_SETTINGS][EVALUATED_PERIOD][VALUE] = 1
+
     logging.debug("Accessing script: C0_data_processing")
     C0.all(dict_values)
 


### PR DESCRIPTION
Fix github action timeout

**Changes proposed in this pull request**:
- Skip benchmark KPI test as it was seen to be consuming the whole test time leading to timeout(All tests beside KPI take 33s to run online versus 7.5s on my laptop)
- Reduce to one day the tests where simulation results are not important (for E and D test modules setup)

Maybe the computational power allocated to github action is too limited to run simulations, the solution would then be to keep the running simulation tests local

The following steps were realized, as well (if applies):
- [x] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
