### PR TITLE
Fix formula of degree of NZE in RTD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Here is a template for new release sections
 ### Fixed
 - Skip `test_benchmark_KPI` as it was seen to be consuming the whole test time leading to timeout on github action (#826)
 - Reduce `simulation_settings.evaluated_period` to one day for the tests where simulation results are not important (for E0 and D2 test modules setup) (#826)
+- Fix formula of degree of NZE in RTD (#832)
 
 ## [0.5.5] - 2021-03-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Here is a template for new release sections
 ### Fixed
 - Skip `test_benchmark_KPI` as it was seen to be consuming the whole test time leading to timeout on github action (#826)
 - Reduce `simulation_settings.evaluated_period` to one day for the tests where simulation results are not important (for E0 and D2 test modules setup) (#826)
-- Fix formula of degree of NZE in RTD (#832)
+- Fix formula of degree of NZE in RTD and in docstring of `E3.equation_degree_of_net_zero_energy()`  (#832)
 
 ## [0.5.5] - 2021-03-04
 

--- a/docs/MVS_Outputs.rst
+++ b/docs/MVS_Outputs.rst
@@ -296,7 +296,7 @@ and a degree of NZE higher 1 a plus-energy system.
 As above, we apply a weighting based on Electricity Equivalent.
 
 .. math::
-        Degree of NZE &=\frac{1 + (\sum_{i} {E_{grid feedin}(i)} \cdot w_i - E_{grid consumption} (i) \cdot w_i)}{\sum_i {E_{demand, i} \cdot w_i}}
+        Degree of NZE &= 1 + \frac{(\sum_{i} {E_{grid feedin}(i)} \cdot w_i - E_{grid consumption} (i) \cdot w_i)}{\sum_i {E_{demand, i} \cdot w_i}}
 
 
 Automatic Report

--- a/src/multi_vector_simulator/E3_indicator_calculation.py
+++ b/src/multi_vector_simulator/E3_indicator_calculation.py
@@ -666,7 +666,7 @@ def equation_degree_of_net_zero_energy(
     -----
 
     .. math::
-        Degree of NZE &=\frac{1 + (\sum_{i} {E_{grid feedin}(i)} \cdot w_i - E_{grid consumption} (i) \cdot w_i)}{\sum_i {E_{demand, i} \cdot w_i}}
+        Degree of NZE &= 1 + \frac{(\sum_{i} {E_{grid feedin}(i)} \cdot w_i - E_{grid consumption} (i) \cdot w_i)}{\sum_i {E_{demand, i} \cdot w_i}}
 
     Degree of NZE = 1 : System is a net zero energy system, as E_feedin = E_grid_consumption
     Degree of NZE > 1 : system is a plus-energy system, as E_feedin > E_grid_consumption


### PR DESCRIPTION
Fix #Issue

**Changes proposed in this pull request**:
- Fix formula of degree of NZE in RTD

correct formula: `degree_of_nze = 1 + (total_feedin - total_grid_consumption) / total_demand`

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
