### PR TITLE
Fix failing pytests (limited to Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,13 @@ Here is a template for new release sections
 - Add check for correct `installedcap` processing to `AB_grid_pv` benchmark test (#831)
 - Add check to `AB_grid_pv` benchmark test: total pv generation is used to cover demand (#831)
 - Section on energy consumption assets in `Model_Assumptions.rst` and `MVS_Outputs.rst` (#817)
+- Constant variables: `MODELLING_TIME`, `LP_FILE`
 
 ### Changed
 - Update the release protocol in `CONTRIBUTING.md` (#821)
 - Status messages of requirements in `E-Land_Requirements.rst` (#817)
 - Minor updates in `Model_Assumptions.rst` and `MVS_Outputs.rst`, mainly adding labels (#817)
+- Pytests for `D0` to let them pass on Windows ()
 
 ### Removed
 -
@@ -38,6 +40,7 @@ Here is a template for new release sections
 - Skip `test_benchmark_KPI` as it was seen to be consuming the whole test time leading to timeout on github action (#826)
 - Reduce `simulation_settings.evaluated_period` to one day for the tests where simulation results are not important (for E0 and D2 test modules setup) (#826)
 - Fix formula of degree of NZE in RTD and in docstring of `E3.equation_degree_of_net_zero_energy()`  (#832)
+- Tests failing on windows with `FileExistsError` ()
 
 ## [0.5.5] - 2021-03-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,13 @@ Here is a template for new release sections
 - Add check for correct `installedcap` processing to `AB_grid_pv` benchmark test (#831)
 - Add check to `AB_grid_pv` benchmark test: total pv generation is used to cover demand (#831)
 - Section on energy consumption assets in `Model_Assumptions.rst` and `MVS_Outputs.rst` (#817)
-- Constant variables: `MODELLING_TIME`, `LP_FILE`
+- Constant variables: `MODELLING_TIME`, `LP_FILE` (#839)
 
 ### Changed
 - Update the release protocol in `CONTRIBUTING.md` (#821)
 - Status messages of requirements in `E-Land_Requirements.rst` (#817)
 - Minor updates in `Model_Assumptions.rst` and `MVS_Outputs.rst`, mainly adding labels (#817)
-- Pytests for `D0` to let them pass on Windows ()
+- Pytests for `D0` to let them pass on Windows (#839)
 
 ### Removed
 -
@@ -40,7 +40,7 @@ Here is a template for new release sections
 - Skip `test_benchmark_KPI` as it was seen to be consuming the whole test time leading to timeout on github action (#826)
 - Reduce `simulation_settings.evaluated_period` to one day for the tests where simulation results are not important (for E0 and D2 test modules setup) (#826)
 - Fix formula of degree of NZE in RTD and in docstring of `E3.equation_degree_of_net_zero_energy()`  (#832)
-- Tests failing on windows with `FileExistsError` ()
+- Tests failing on windows with `FileExistsError` (#839)
 
 ## [0.5.5] - 2021-03-04
 

--- a/src/multi_vector_simulator/D0_modelling_and_optimization.py
+++ b/src/multi_vector_simulator/D0_modelling_and_optimization.py
@@ -34,6 +34,7 @@ from multi_vector_simulator.utils.constants import (
     ES_GRAPH,
     PATHS_TO_PLOTS,
     PLOTS_ES,
+    LP_FILE,
 )
 from multi_vector_simulator.utils.constants_json_strings import (
     ENERGY_BUSSES,
@@ -254,7 +255,7 @@ class model_building:
         """
         if dict_values[SIMULATION_SETTINGS][OUTPUT_LP_FILE][VALUE] is True:
             path_lp_file = os.path.join(
-                dict_values[SIMULATION_SETTINGS][PATH_OUTPUT_FOLDER], "lp_file.lp"
+                dict_values[SIMULATION_SETTINGS][PATH_OUTPUT_FOLDER], LP_FILE
             )
             logging.debug("Saving to lp-file.")
             local_energy_system.write(

--- a/src/multi_vector_simulator/D0_modelling_and_optimization.py
+++ b/src/multi_vector_simulator/D0_modelling_and_optimization.py
@@ -53,6 +53,7 @@ from multi_vector_simulator.utils.constants_json_strings import (
     SIMULATION_RESULTS,
     OBJECTIVE_VALUE,
     SIMULTATION_TIME,
+    MODELLING_TIME,
 )
 
 from multi_vector_simulator.utils.exceptions import (
@@ -372,9 +373,9 @@ class timer:
         Simulation time in dict_values
         """
         duration = timeit.default_timer() - start
-        dict_values[SIMULATION_RESULTS].update({"modelling_time": round(duration, 2)})
+        dict_values[SIMULATION_RESULTS].update({MODELLING_TIME: round(duration, 2)})
 
         logging.info(
             "Modeling time: %s minutes.",
-            round(dict_values[SIMULATION_RESULTS]["modelling_time"] / 60, 2),
+            round(dict_values[SIMULATION_RESULTS][MODELLING_TIME] / 60, 2),
         )

--- a/src/multi_vector_simulator/utils/constants.py
+++ b/src/multi_vector_simulator/utils/constants.py
@@ -39,6 +39,8 @@ INPUTS_COPY = INPUT_FOLDER
 LOGFILE = "mvs_logfile.log"
 # name of the automatically generated pdf report
 PDF_REPORT = "simulation_report.pdf"
+# name of lp file stored to dick
+LP_FILE = "lp_file.lp"
 
 # path of the pdf report path
 REPORT_FOLDER = "report"

--- a/src/multi_vector_simulator/utils/constants_json_strings.py
+++ b/src/multi_vector_simulator/utils/constants_json_strings.py
@@ -198,6 +198,7 @@ SIMULATION_RESULTS = "simulation_results"
 # oemof simulation parameters:
 OBJECTIVE_VALUE = "objective_value"
 SIMULTATION_TIME = "simulation_time"
+MODELLING_TIME = "modelling_time"
 
 # Logs
 LOGS = "logs"

--- a/tests/test_C0_data_processing.py
+++ b/tests/test_C0_data_processing.py
@@ -1098,7 +1098,6 @@ def test_compute_timeseries_properties_TIMESERIES_in_dict_asset():
     }
 
     C0.compute_timeseries_properties(dict_asset)
-    print(dict_asset)
 
     for parameter in [
         TIMESERIES_PEAK,

--- a/tests/test_D0_modelling_and_optimization.py
+++ b/tests/test_D0_modelling_and_optimization.py
@@ -178,8 +178,14 @@ def test_error_raise_MVSOemofError_if_solver_could_not_finish_simulation(margs):
 PATH_ES_GRAPH = os.path.join(TEST_OUTPUT_PATH, ES_GRAPH)
 
 
+def setup_function():
+    if os.path.exists(TEST_OUTPUT_PATH):
+        shutil.rmtree(TEST_OUTPUT_PATH, ignore_errors=True, onerror=None)
+    os.mkdir(TEST_OUTPUT_PATH)
+
+
 def test_networkx_graph_requested_store_nx_graph_true(dict_values):
-    shutil.rmtree(TEST_OUTPUT_PATH, ignore_errors=True, onerror=None)
+    setup_function()
     assert (
         os.path.isfile(PATH_ES_GRAPH) is False
     ), f"The {PATH_ES_GRAPH} does already exist before the test is run it should be non-existant, so the test can not be executed."
@@ -196,7 +202,7 @@ def test_networkx_graph_requested_store_nx_graph_true(dict_values):
 
 
 def test_networkx_graph_requested_store_nx_graph_false(dict_values):
-    shutil.rmtree(TEST_OUTPUT_PATH, ignore_errors=True)
+    setup_function()
     assert (
         os.path.isfile(PATH_ES_GRAPH) is False
     ), f"The {PATH_ES_GRAPH} does already exist before the test is run it should be non-existant, so the test can not be executed."
@@ -216,7 +222,7 @@ path_lp_file = os.path.join(TEST_OUTPUT_PATH, LP_FILE)
 
 
 def test_if_lp_file_is_stored_to_file_if_output_lp_file_true(dict_values):
-    shutil.rmtree(TEST_OUTPUT_PATH, ignore_errors=True)
+    setup_function()
     assert (
         os.path.isfile(path_lp_file) is False
     ), f"The {LP_FILE} does exist before the test is run eventhough it should be non-existant, so the test can not be executed."
@@ -233,7 +239,7 @@ def test_if_lp_file_is_stored_to_file_if_output_lp_file_true(dict_values):
 
 
 def test_if_lp_file_is_stored_to_file_if_output_lp_file_false(dict_values):
-    shutil.rmtree(TEST_OUTPUT_PATH, ignore_errors=True)
+    setup_function()
     assert (
         os.path.isfile(path_lp_file) is False
     ), f"The {LP_FILE} does already exist before the test is run it should be non-existant, so the test can not be executed."

--- a/tests/test_D0_modelling_and_optimization.py
+++ b/tests/test_D0_modelling_and_optimization.py
@@ -30,6 +30,7 @@ from multi_vector_simulator.utils.constants_json_strings import (
     SIMULATION_RESULTS,
     OBJECTIVE_VALUE,
     SIMULTATION_TIME,
+    MODELLING_TIME,
     ASSET_DICT,
     ENERGY_VECTOR,
 )
@@ -105,8 +106,12 @@ def test_if_model_building_time_measured_and_stored():
     dict_values = {SIMULATION_RESULTS: {}}
     start = D0.timer.initalize()
     D0.timer.stop(dict_values, start)
-    assert "modelling_time" in dict_values[SIMULATION_RESULTS]
-    assert isinstance(dict_values[SIMULATION_RESULTS]["modelling_time"], float)
+    assert (
+        MODELLING_TIME in dict_values[SIMULATION_RESULTS]
+    ), f"The simulation time has not been added to to simulation results."
+    assert isinstance(
+        dict_values[SIMULATION_RESULTS][MODELLING_TIME], float
+    ), f"The simulation time should be a floating number."
 
 
 def test_energysystem_initialized(dict_values_minimal):
@@ -119,7 +124,9 @@ def test_energysystem_initialized(dict_values_minimal):
         OEMOF_GEN_STORAGE,
     ):
         assert k in dict_model.keys()
-    assert isinstance(model, oemof.solph.network.EnergySystem)
+    assert isinstance(
+        model, oemof.solph.network.EnergySystem
+    ), f"The oemof model has not been successfully created."
 
 
 def test_oemof_adding_assets_from_dict_values_passes(dict_values):

--- a/tests/test_D0_modelling_and_optimization.py
+++ b/tests/test_D0_modelling_and_optimization.py
@@ -11,6 +11,8 @@ from multi_vector_simulator.cli import main
 import multi_vector_simulator.D0_modelling_and_optimization as D0
 from multi_vector_simulator.B0_data_input_json import load_json
 
+from multi_vector_simulator.utils.constants import LP_FILE
+
 from multi_vector_simulator.utils.constants_json_strings import (
     ENERGY_BUSSES,
     ENERGY_CONSUMPTION,
@@ -200,7 +202,8 @@ class FileCreation:
         )
         assert os.path.exists(PATH_ES_GRAPH) is False
 
-    path_lp_file = os.path.join(TEST_OUTPUT_PATH, "lp_file.lp")
+path_lp_file = os.path.join(TEST_OUTPUT_PATH, LP_FILE)
+
 
     def test_if_lp_file_is_stored_to_file_if_output_lp_file_true(dict_values):
         model, dict_model = D0.model_building.initialize(dict_values)

--- a/tests/test_D0_modelling_and_optimization.py
+++ b/tests/test_D0_modelling_and_optimization.py
@@ -179,59 +179,52 @@ def test_error_raise_MVSOemofError_if_solver_could_not_finish_simulation(margs):
 PATH_ES_GRAPH = os.path.join(TEST_OUTPUT_PATH, ES_GRAPH)
 
 
-def test_networkx_graph_requested_store_nx_graph_true(dict_values):
-    model, dict_model = D0.model_building.initialize(dict_values)
-    D0.model_building.adding_assets_to_energysystem_model(
-        dict_values, dict_model, model
-    )
-    D0.model_building.plot_networkx_graph(
-        dict_values, model, save_energy_system_graph=True
-    )
-    assert os.path.exists(PATH_ES_GRAPH) is True
+class FileCreation:
+    def test_networkx_graph_requested_store_nx_graph_true(dict_values):
+        model, dict_model = D0.model_building.initialize(dict_values)
+        D0.model_building.adding_assets_to_energysystem_model(
+            dict_values, dict_model, model
+        )
+        D0.model_building.plot_networkx_graph(
+            dict_values, model, save_energy_system_graph=True
+        )
+        assert os.path.exists(PATH_ES_GRAPH) is True
 
+    def test_networkx_graph_requested_store_nx_graph_false(dict_values):
+        model, dict_model = D0.model_building.initialize(dict_values)
+        D0.model_building.adding_assets_to_energysystem_model(
+            dict_values, dict_model, model
+        )
+        D0.model_building.plot_networkx_graph(
+            dict_values, model, save_energy_system_graph=False
+        )
+        assert os.path.exists(PATH_ES_GRAPH) is False
 
-def test_networkx_graph_requested_store_nx_graph_false(dict_values):
-    model, dict_model = D0.model_building.initialize(dict_values)
-    D0.model_building.adding_assets_to_energysystem_model(
-        dict_values, dict_model, model
-    )
-    D0.model_building.plot_networkx_graph(
-        dict_values, model, save_energy_system_graph=False
-    )
-    assert os.path.exists(PATH_ES_GRAPH) is False
+    path_lp_file = os.path.join(TEST_OUTPUT_PATH, "lp_file.lp")
 
+    def test_if_lp_file_is_stored_to_file_if_output_lp_file_true(dict_values):
+        model, dict_model = D0.model_building.initialize(dict_values)
+        model = D0.model_building.adding_assets_to_energysystem_model(
+            dict_values, dict_model, model
+        )
+        local_energy_system = oemof.solph.Model(model)
+        dict_values[SIMULATION_SETTINGS][OUTPUT_LP_FILE].update({VALUE: True})
+        D0.model_building.store_lp_file(dict_values, local_energy_system)
+        assert os.path.exists(path_lp_file) is True
 
-import oemof.solph as solph
+    def test_if_lp_file_is_stored_to_file_if_output_lp_file_false(dict_values):
+        model, dict_model = D0.model_building.initialize(dict_values)
+        model = D0.model_building.adding_assets_to_energysystem_model(
+            dict_values, dict_model, model
+        )
+        local_energy_system = oemof.solph.Model(model)
+        dict_values[SIMULATION_SETTINGS][OUTPUT_LP_FILE].update({VALUE: False})
+        D0.model_building.store_lp_file(dict_values, local_energy_system)
+        assert os.path.exists(path_lp_file) is False
 
-path_lp_file = os.path.join(TEST_OUTPUT_PATH, "lp_file.lp")
+    path_oemof_file = os.path.join(TEST_OUTPUT_PATH, "oemof_simulation_results.oemof")
 
-
-def test_if_lp_file_is_stored_to_file_if_output_lp_file_true(dict_values):
-    model, dict_model = D0.model_building.initialize(dict_values)
-    model = D0.model_building.adding_assets_to_energysystem_model(
-        dict_values, dict_model, model
-    )
-    local_energy_system = solph.Model(model)
-    dict_values[SIMULATION_SETTINGS][OUTPUT_LP_FILE].update({VALUE: True})
-    D0.model_building.store_lp_file(dict_values, local_energy_system)
-    assert os.path.exists(path_lp_file) is True
-
-
-def test_if_lp_file_is_stored_to_file_if_output_lp_file_false(dict_values):
-    model, dict_model = D0.model_building.initialize(dict_values)
-    model = D0.model_building.adding_assets_to_energysystem_model(
-        dict_values, dict_model, model
-    )
-    local_energy_system = solph.Model(model)
-    dict_values[SIMULATION_SETTINGS][OUTPUT_LP_FILE].update({VALUE: False})
-    D0.model_building.store_lp_file(dict_values, local_energy_system)
-    assert os.path.exists(path_lp_file) is False
-
-
-path_oemof_file = os.path.join(TEST_OUTPUT_PATH, "oemof_simulation_results.oemof")
-
-
-def test_if_simulation_results_added_to_dict_values(dict_values):
-    D0.run_oemof(dict_values)
-    for k in (LABEL, OBJECTIVE_VALUE, SIMULTATION_TIME):
-        assert k in dict_values[SIMULATION_RESULTS].keys()
+    def test_if_simulation_results_added_to_dict_values(dict_values):
+        D0.run_oemof(dict_values)
+        for k in (LABEL, OBJECTIVE_VALUE, SIMULTATION_TIME):
+            assert k in dict_values[SIMULATION_RESULTS].keys()

--- a/tests/test_D0_modelling_and_optimization.py
+++ b/tests/test_D0_modelling_and_optimization.py
@@ -92,16 +92,6 @@ def dict_values_minimal():
     }
 
 
-def setup_function():
-    if os.path.exists(TEST_OUTPUT_PATH):
-        shutil.rmtree(TEST_OUTPUT_PATH, ignore_errors=True)
-    os.mkdir(TEST_OUTPUT_PATH)
-
-
-def teardown_function():
-    shutil.rmtree(TEST_OUTPUT_PATH, ignore_errors=True)
-
-
 def test_if_model_building_time_measured_and_stored():
     dict_values = {SIMULATION_RESULTS: {}}
     start = D0.timer.initalize()
@@ -188,53 +178,78 @@ def test_error_raise_MVSOemofError_if_solver_could_not_finish_simulation(margs):
 PATH_ES_GRAPH = os.path.join(TEST_OUTPUT_PATH, ES_GRAPH)
 
 
-class FileCreation:
-    def test_networkx_graph_requested_store_nx_graph_true(dict_values):
-        model, dict_model = D0.model_building.initialize(dict_values)
-        D0.model_building.adding_assets_to_energysystem_model(
-            dict_values, dict_model, model
-        )
-        D0.model_building.plot_networkx_graph(
-            dict_values, model, save_energy_system_graph=True
-        )
-        assert os.path.exists(PATH_ES_GRAPH) is True
+def test_networkx_graph_requested_store_nx_graph_true(dict_values):
+    shutil.rmtree(TEST_OUTPUT_PATH, ignore_errors=True, onerror=None)
+    assert (
+        os.path.isfile(PATH_ES_GRAPH) is False
+    ), f"The {PATH_ES_GRAPH} does already exist before the test is run it should be non-existant, so the test can not be executed."
+    model, dict_model = D0.model_building.initialize(dict_values)
+    D0.model_building.adding_assets_to_energysystem_model(
+        dict_values, dict_model, model
+    )
+    D0.model_building.plot_networkx_graph(
+        dict_values, model, save_energy_system_graph=True
+    )
+    assert (
+        os.path.isfile(PATH_ES_GRAPH) is True
+    ), f"Eventhough the energy system graph is requested, it is not stored to disk"
 
-    def test_networkx_graph_requested_store_nx_graph_false(dict_values):
-        model, dict_model = D0.model_building.initialize(dict_values)
-        D0.model_building.adding_assets_to_energysystem_model(
-            dict_values, dict_model, model
-        )
-        D0.model_building.plot_networkx_graph(
-            dict_values, model, save_energy_system_graph=False
-        )
-        assert os.path.exists(PATH_ES_GRAPH) is False
+
+def test_networkx_graph_requested_store_nx_graph_false(dict_values):
+    shutil.rmtree(TEST_OUTPUT_PATH, ignore_errors=True)
+    assert (
+        os.path.isfile(PATH_ES_GRAPH) is False
+    ), f"The {PATH_ES_GRAPH} does already exist before the test is run it should be non-existant, so the test can not be executed."
+    model, dict_model = D0.model_building.initialize(dict_values)
+    D0.model_building.adding_assets_to_energysystem_model(
+        dict_values, dict_model, model
+    )
+    D0.model_building.plot_networkx_graph(
+        dict_values, model, save_energy_system_graph=False
+    )
+    assert (
+        os.path.isfile(PATH_ES_GRAPH) is False
+    ), f"Eventhough the energy system graph is not requested, it is stored to disk"
+
 
 path_lp_file = os.path.join(TEST_OUTPUT_PATH, LP_FILE)
 
 
-    def test_if_lp_file_is_stored_to_file_if_output_lp_file_true(dict_values):
-        model, dict_model = D0.model_building.initialize(dict_values)
-        model = D0.model_building.adding_assets_to_energysystem_model(
-            dict_values, dict_model, model
-        )
-        local_energy_system = oemof.solph.Model(model)
-        dict_values[SIMULATION_SETTINGS][OUTPUT_LP_FILE].update({VALUE: True})
-        D0.model_building.store_lp_file(dict_values, local_energy_system)
-        assert os.path.exists(path_lp_file) is True
+def test_if_lp_file_is_stored_to_file_if_output_lp_file_true(dict_values):
+    shutil.rmtree(TEST_OUTPUT_PATH, ignore_errors=True)
+    assert (
+        os.path.isfile(path_lp_file) is False
+    ), f"The {LP_FILE} does exist before the test is run eventhough it should be non-existant, so the test can not be executed."
+    model, dict_model = D0.model_building.initialize(dict_values)
+    model = D0.model_building.adding_assets_to_energysystem_model(
+        dict_values, dict_model, model
+    )
+    local_energy_system = oemof.solph.Model(model)
+    dict_values[SIMULATION_SETTINGS][OUTPUT_LP_FILE].update({VALUE: True})
+    D0.model_building.store_lp_file(dict_values, local_energy_system)
+    assert (
+        os.path.isfile(path_lp_file) is True
+    ), f"Eventhough the {LP_FILE} is requested, it is not stored to disk"
 
-    def test_if_lp_file_is_stored_to_file_if_output_lp_file_false(dict_values):
-        model, dict_model = D0.model_building.initialize(dict_values)
-        model = D0.model_building.adding_assets_to_energysystem_model(
-            dict_values, dict_model, model
-        )
-        local_energy_system = oemof.solph.Model(model)
-        dict_values[SIMULATION_SETTINGS][OUTPUT_LP_FILE].update({VALUE: False})
-        D0.model_building.store_lp_file(dict_values, local_energy_system)
-        assert os.path.exists(path_lp_file) is False
 
-    path_oemof_file = os.path.join(TEST_OUTPUT_PATH, "oemof_simulation_results.oemof")
+def test_if_lp_file_is_stored_to_file_if_output_lp_file_false(dict_values):
+    shutil.rmtree(TEST_OUTPUT_PATH, ignore_errors=True)
+    assert (
+        os.path.isfile(path_lp_file) is False
+    ), f"The {LP_FILE} does already exist before the test is run it should be non-existant, so the test can not be executed."
+    model, dict_model = D0.model_building.initialize(dict_values)
+    model = D0.model_building.adding_assets_to_energysystem_model(
+        dict_values, dict_model, model
+    )
+    local_energy_system = oemof.solph.Model(model)
+    dict_values[SIMULATION_SETTINGS][OUTPUT_LP_FILE].update({VALUE: False})
+    D0.model_building.store_lp_file(dict_values, local_energy_system)
+    assert (
+        os.path.isfile(path_lp_file) is False
+    ), f"Eventhough the {LP_FILE} is not requested, it is stored to disk"
 
-    def test_if_simulation_results_added_to_dict_values(dict_values):
-        D0.run_oemof(dict_values)
-        for k in (LABEL, OBJECTIVE_VALUE, SIMULTATION_TIME):
-            assert k in dict_values[SIMULATION_RESULTS].keys()
+
+def test_if_simulation_results_added_to_dict_values(dict_values):
+    D0.run_oemof(dict_values)
+    for k in (LABEL, OBJECTIVE_VALUE, SIMULTATION_TIME):
+        assert k in dict_values[SIMULATION_RESULTS].keys()


### PR DESCRIPTION
There are a couple of tests that terminate or fail on windows only. This PR should fix that behaviour.

**Changes proposed in this pull request**:
- Fix tests failing on windows with `FileExistsError`
- Changed pytests for `D0` to let them pass on Windows
- Added constant variables: `MODELLING_TIME`, `LP_FILE`

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [x] For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)