### PR TITLE
Sort out dependencies in requirements.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,14 @@ Here is a template for new release sections
 - Add check to `AB_grid_pv` benchmark test: total pv generation is used to cover demand (#831)
 - Section on energy consumption assets in `Model_Assumptions.rst` and `MVS_Outputs.rst` (#817)
 - Constant variables: `MODELLING_TIME`, `LP_FILE` (#839)
+- Add plotly in `requirements/default.txt` (#840)
 
 ### Changed
 - Update the release protocol in `CONTRIBUTING.md` (#821)
 - Status messages of requirements in `E-Land_Requirements.rst` (#817)
 - Minor updates in `Model_Assumptions.rst` and `MVS_Outputs.rst`, mainly adding labels (#817)
 - Pytests for `D0` to let them pass on Windows (#839)
+- Update pyomo and pandas dependencies (#840)
 
 ### Removed
 -

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,6 @@
 oemof.solph>=0.4.1
 pandas>=0.24.0,<=1.0.5
+pyomo!=5.7.3 # version 5.7.3 make mvs very slow
 graphviz>=0.14.1
 openpyxl>=3.0.5
 xlrd==1.2.0

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -2,6 +2,9 @@ oemof.solph>=0.4.1
 pandas>=0.24.0,<=1.0.5
 pyomo!=5.7.3 # version 5.7.3 make mvs very slow
 graphviz>=0.14.1
+plotly
+psutil
+kaleido>=0.0.2
 openpyxl>=3.0.5
 xlrd==1.2.0
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
 oemof.solph>=0.4.1
-pandas>=0.24.0,<=1.0.5
+pandas>=0.24.0,!=1.1.0,!=1.1.1,!=1.1.2
 pyomo!=5.7.3 # version 5.7.3 make mvs very slow
 graphviz>=0.14.1
 plotly


### PR DESCRIPTION
Fix #836, fix #760, fix #200

I tried python 3.8 and 3.9, I let install the latest panda version (v1.2.3, .. happen only once ^^) and all the tests ran smoothly
Except one in `TestACElectricityBus.test_benchmark_AB_grid_pv` where it is a type mismatch which leads the two timeseries to not equal (one is int64, whereas the other float64) --> easily fixable. I would therefore suggest we use the latest panda version again.

**Changes proposed in this pull request**:
- Forbid pyomo v 5.7.3
- add plotly to the default to generate pngs

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [ ] Update the CHANGELOG.md
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
