### PR TITLE
Change tests/inputs

### DIFF
--- a/tests/inputs/csv_elements/constraints.csv
+++ b/tests/inputs/csv_elements/constraints.csv
@@ -1,5 +1,5 @@
 ,unit,constraints
-minimal_renewable_factor,factor,0
+minimal_renewable_factor,factor,0.01
 maximum_emissions,kgCO2eq/a,8000000
-minimal_degree_of_autonomy,factor,0
+minimal_degree_of_autonomy,factor,0.01
 net_zero_energy,bool,False

--- a/tests/inputs/csv_elements/energyProduction.csv
+++ b/tests/inputs/csv_elements/energyProduction.csv
@@ -1,7 +1,7 @@
 ,unit,PV_plant_(mono),Diesel
 unit,str,kWp,l
 optimizeCap,bool,True,True
-maximumCap,None or float,1000,None
+maximumCap,None or float,10000,None
 installedCap,kWp,50,0
 age_installed,year,0,0
 lifetime,year,30,20

--- a/tests/inputs/csv_elements/energyProviders.csv
+++ b/tests/inputs/csv_elements/energyProviders.csv
@@ -2,7 +2,7 @@
 unit,str,kW
 optimizeCap,bool,True
 energy_price,currency/kWh,0.1
-feedin_tariff,currency/kWh,0.005
+feedin_tariff,currency/kWh,0.05
 peak_demand_pricing,currency/kW,60
 peak_demand_pricing_period,"times per year (1,2,3,4,6,12)",2
 renewable_share,factor,0.1

--- a/tests/inputs/mvs_config.json
+++ b/tests/inputs/mvs_config.json
@@ -6,11 +6,11 @@
         },
         "minimal_degree_of_autonomy": {
             "unit": "factor",
-            "value": 0
+            "value": 0.01
         },
         "minimal_renewable_factor": {
             "unit": "factor",
-            "value": 0
+            "value": 0.01
         },
         "net_zero_energy": {
             "unit": "bool",
@@ -438,7 +438,7 @@
             },
             "maximumCap": {
                 "unit": "None or float",
-                "value": 1000
+                "value": 10000
             },
             "optimizeCap": {
                 "unit": "bool",
@@ -474,7 +474,7 @@
             },
             "feedin_tariff": {
                 "unit": "currency/kWh",
-                "value": 0.005
+                "value": 0.05
             },
             "inflow_direction": "Electricity (DSO)",
             "label": "Electricity_grid_DSO",


### PR DESCRIPTION
These inputs can still be used to test the `minimal_renewable_share` and `minimal_degree_of_autonomy` constraint as well as `maximumCap` constraints. PV timeseries unchanged.