### PR TITLE
Fix failing test with latest pandas version

### DIFF
--- a/tests/test_benchmark_scenarios.py
+++ b/tests/test_benchmark_scenarios.py
@@ -11,6 +11,7 @@ import json
 
 import mock
 import pandas as pd
+import numpy as np
 import pytest
 from pytest import approx
 from pandas.util.testing import assert_series_equal
@@ -145,7 +146,7 @@ class TestACElectricityBus:
         result_time_series_pv.index = input_time_series_pv_shortened.index
 
         assert_series_equal(
-            result_time_series_pv,
+            result_time_series_pv.astype(np.float64),
             input_time_series_pv_shortened * installed_capacity,
             check_names=False,
         )


### PR DESCRIPTION
Fix failing test with pandas 1.2.3

**Changes proposed in this pull request**:
- Changed the type of a series from int to float for series comparison not to fail

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [ ] Update the CHANGELOG.md
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
