### PR TITLE
Feature/store version number in sim settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Here is a template for new release sections
 - Add check for the capability of asset capacities in an energy system to fulfill the maximum demand in `C1.check_energy_system_can_fulfill_max_demand()` (#824)
 - Add tests for `C1.check_energy_system_can_fulfill_max_demand()`, including pseudo-benchmark test in `test_C1` (#824)
 - Zenodo badge on README (#850)
-- `VERSION_NUM` to simulation settings, added with `C0.add_version_number_used()`
+- `VERSION_NUM` to simulation settings, added with `C0.add_version_number_used()` (#855)
 
 ### Changed
 - Update the release protocol in `CONTRIBUTING.md` (#821)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Here is a template for new release sections
 - Add check for the capability of asset capacities in an energy system to fulfill the maximum demand in `C1.check_energy_system_can_fulfill_max_demand()` (#824)
 - Add tests for `C1.check_energy_system_can_fulfill_max_demand()`, including pseudo-benchmark test in `test_C1` (#824)
 - Zenodo badge on README (#850)
+- `VERSION_NUM` to simulation settings, added with `C0.add_version_number_used()`
 
 ### Changed
 - Update the release protocol in `CONTRIBUTING.md` (#821)

--- a/src/multi_vector_simulator/C0_data_processing.py
+++ b/src/multi_vector_simulator/C0_data_processing.py
@@ -27,6 +27,7 @@ import sys
 import pprint as pp
 import pandas as pd
 import warnings
+from multi_vector_simulator.version import version_num
 
 from multi_vector_simulator.utils.constants import (
     TIME_SERIES,
@@ -56,7 +57,7 @@ def all(dict_values):
     """
     # Check if any asset label has duplicates
     C1.check_for_label_duplicates(dict_values)
-
+    add_version_number_used(dict_values[SIMULATION_SETTINGS])
     B0.retrieve_date_time_info(dict_values[SIMULATION_SETTINGS])
     add_economic_parameters(dict_values[ECONOMIC_DATA])
     define_energy_vectors_from_busses(dict_values)
@@ -97,6 +98,24 @@ def all(dict_values):
     # check installed and maximum capacity of all conversion, generation and storage assets
     # connected to one bus is smaller than the maximum demand
     C1.check_energy_system_can_fulfill_max_demand(dict_values)
+
+
+def add_version_number_used(simulation_settings):
+    r"""
+    Add version number to simulation settings
+
+    Parameters
+    ----------
+    simulation_settings: dict
+        Dict of simulation settings
+
+    Returns
+    -------
+    Updated dict simulation_settings with `VERSION_NUM` equal to local version number.
+    This version number will be added to the json output files.
+    The automatic report generated in `F0` references the version number and date on its own accord.
+    """
+    simulation_settings.update({VERSION_NUM: version_num})
 
 
 def define_energy_vectors_from_busses(dict_values):

--- a/src/multi_vector_simulator/utils/constants_json_strings.py
+++ b/src/multi_vector_simulator/utils/constants_json_strings.py
@@ -140,6 +140,9 @@ TIMESERIES_TOTAL = "timeseries_total"
 TIMESERIES_AVERAGE = "timeseries_average"
 TIMESERIES_SOC = "timeseries_soc"
 
+# Other pre-processing
+VERSION_NUM = "Version number"
+
 # Pre-processing cost parameters
 ANNUITY_FACTOR = "annuity_factor"
 CRF = "CRF"

--- a/tests/test_C0_data_processing.py
+++ b/tests/test_C0_data_processing.py
@@ -82,8 +82,11 @@ from multi_vector_simulator.utils.constants_json_strings import (
     TIMESERIES_AVERAGE,
     TIMESERIES_NORMALIZED,
     FIX_COST,
+    VERSION_NUM,
 )
 from multi_vector_simulator.utils.exceptions import InvalidPeakDemandPricingPeriodsError
+
+from multi_vector_simulator.version import version_num
 
 
 def test_add_economic_parameters():
@@ -1181,6 +1184,13 @@ def test_process_all_assets_fixcost():
     assert (
         LIFETIME_PRICE_DISPATCH not in dict_test[FIX_COST][fix_cost_entry]
     ), f"Parameter {LIFETIME_PRICE_DISPATCH} should not be calculated for {FIX_COST} entries."
+
+
+def test_add_version_number_used():
+    settings = {}
+    C0.add_version_number_used(settings)
+    assert VERSION_NUM in settings
+    assert settings[VERSION_NUM] == version_num
 
 
 """


### PR DESCRIPTION
Fix #657

**Changes proposed in this pull request**:
- `VERSION_NUM` to simulation settings, added with `C0.add_version_number_used()`

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [x] For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)