### PR TITLE
Use the badges only for html production and not latex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Here is a template for new release sections
 - Function `C0.define_sink()` now also defines `DISPATCHABILITY=TRUE` for the created sink.
 - Only implement the constraints defined by the user explicitly: move accessing the constraint key in `dict_value` in the respective constraint preparation functions (#845)
 - Readthedocs restructure of chapters (#853)
+- Load svg badges only for html readthedocs (#857)
 
 
 ### Removed

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,22 @@
 
 Multi-vector simulator
 ======================
-|badge_docs| |badge_CI| |badge_coverage| |badge_zenodo|
+
+.. only:: html
+    .. image:: https://readthedocs.org/projects/multi-vector-simulator/badge/?version=latest
+        :target: https://multi-vector-simulator.readthedocs.io/en/latest/?badge=latest
+        :alt: Documentation Status
+
+    .. image:: https://github.com/rl-institut/multi-vector-simulator/workflows/CI/badge.svg
+        :alt: Build status
+
+    .. image:: https://coveralls.io/repos/github/rl-institut/multi-vector-simulator/badge.svg
+        :target: https://coveralls.io/github/rl-institut/multi-vector-simulator
+        :alt: Test coverage
+
+    .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4610237.svg
+       :target: https://doi.org/10.5281/zenodo.4610237
+       :alt: Zenodo DOI
 
 The MVS' global flowchart, or graphical model, is divided into three connected blocks that trace the logic sequence: inputs, system model, and outputs. This is a typical representation of a simulation model.
 
@@ -107,23 +122,6 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-
-
-
-.. |badge_docs| image:: https://readthedocs.org/projects/multi-vector-simulator/badge/?version=latest
-    :target: https://multi-vector-simulator.readthedocs.io/en/latest/?badge=latest
-    :alt: Documentation Status
-
-.. |badge_CI| image:: https://github.com/rl-institut/multi-vector-simulator/workflows/CI/badge.svg
-    :alt: Build status
-
-.. |badge_coverage| image:: https://coveralls.io/repos/github/rl-institut/multi-vector-simulator/badge.svg
-    :target: https://coveralls.io/github/rl-institut/multi-vector-simulator
-    :alt: Test coverage
-
-.. |badge_zenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4610237.svg
-   :target: https://doi.org/10.5281/zenodo.4610237
-   :alt: Zenodo DOI
 
 
 


### PR DESCRIPTION
Related to #849 

**Changes proposed in this pull request**:
Escape svg images from badges in latex

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [ ] Update the CHANGELOG.md
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
