### PR TITLE
Fix ReadTheDocs build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Here is a template for new release sections
 - Zenodo badge on README (#850)
 - `VERSION_NUM` to simulation settings, added with `C0.add_version_number_used()` (#855)
 - Generation of pdf version of the readthedocs (#853)
-- `sphinx.ext.imgconverter` in `docs/conf.py` for svg images into pdf (#853)
+- `sphinxcontrib-svg2pdfconverter` in `docs/conf.py` for svg images into pdf (also added in `requirements/docs.txt`(#853)
 
 ### Changed
 - Update the release protocol in `CONTRIBUTING.md` (#821)
@@ -54,8 +54,8 @@ Here is a template for new release sections
 - The `DISPATCHABILITY` of energyConsumption assets is now set to FALSE by default (#824)
 - Function `C0.define_sink()` now also defines `DISPATCHABILITY=TRUE` for the created sink.
 - Only implement the constraints defined by the user explicitly: move accessing the constraint key in `dict_value` in the respective constraint preparation functions (#845)
-- Readthedocs restructure of chapters (#853)
-- Load svg badges only for html readthedocs (#857)
+- Readthedocs restructure of chapters (#853, #860)
+- Load svg badges only for html readthedocs (#857) (reversed in #860)
 
 
 ### Removed

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,6 @@ MVS - Multi-Vector Simulator of the E-Land toolbox
 
 |badge_docs| |badge_CI| |badge_coverage| |badge_zenodo|
 
-Depreciated: |badge_travis|
-
 Rights: `Reiner Lemoine Institut (Berlin) <https://reiner-lemoine-institut.de/>`__
 
 The Multi-Vector Simulator (MVS) allows the evaluation of local sector-coupled energy systems that include the energy carriers electricity, heat and/or gas. The MVS has three main features:
@@ -33,6 +31,23 @@ Maybe you have ideas that can help the MVS move forward? Maybe you noticed a bug
 
 For advanced programmers: You can also use the ``dev`` branch that includes the latest updates and changes.
 You find the changelog `HERE <https://github.com/rl-institut/multi-vector-simulator/blob/dev/CHANGELOG.md>`__.
+
+.. |badge_docs| image:: https://readthedocs.org/projects/multi-vector-simulator/badge/?version=latest
+    :target: https://multi-vector-simulator.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation Status
+
+.. |badge_CI| image:: https://github.com/rl-institut/multi-vector-simulator/workflows/CI/badge.svg
+    :alt: Build status
+
+.. |badge_coverage| image:: https://coveralls.io/repos/github/rl-institut/multi-vector-simulator/badge.svg
+    :target: https://coveralls.io/github/rl-institut/multi-vector-simulator
+    :alt: Test coverage
+
+.. |badge_zenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4610237.svg
+   :target: https://doi.org/10.5281/zenodo.4610237
+   :alt: Zenodo DOI
+
+
 
 ========================
 Getting started with MVS
@@ -234,22 +249,3 @@ github users, we propose a `workflow <https://github.com/rl-institut/multi-vecto
 For advanced programmers: You can also use the dev version that includes the latest updates and changes, but which in
 turn might not be tested. You can find the CHANGELOG.md on
 this `page <https://github.com/rl-institut/multi-vector-simulator/blob/dev/CHANGELOG.md>`__.
-
-.. |badge_docs| image:: https://readthedocs.org/projects/multi-vector-simulator/badge/?version=latest
-    :target: https://multi-vector-simulator.readthedocs.io/en/latest/?badge=latest
-    :alt: Documentation Status
-
-.. |badge_CI| image:: https://github.com/rl-institut/multi-vector-simulator/workflows/CI/badge.svg
-    :alt: Build status
-
-.. |badge_coverage| image:: https://coveralls.io/repos/github/rl-institut/multi-vector-simulator/badge.svg
-    :target: https://coveralls.io/github/rl-institut/multi-vector-simulator
-    :alt: Test coverage
-
-.. |badge_travis| image:: https://travis-ci.com/rl-institut/mvs_eland.svg?branch=dev
-    :target: https://travis-ci.com/rl-institut/mvs_eland
-    :alt: Build status
-
-.. |badge_zenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4610237.svg
-   :target: https://doi.org/10.5281/zenodo.4610237
-   :alt: Zenodo DOI

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -210,7 +210,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.imgmath",
     "sphinx.ext.autosummary",
-    "sphinx.ext.imgconverter",
+    "sphinxcontrib.rsvgconverter",
     "numpydoc",
 ]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,7 +57,7 @@ What started MVS
 Getting Started
 ===============
 
-Follow the  :ref:`Quick start guide <installation-steps>`
+Follow the  :doc:`Quick start guide <Installation>`
 
 .. Documentation
 .. =============
@@ -78,6 +78,14 @@ Follow the  :ref:`Quick start guide <installation-steps>`
    examples/time_series_params
    examples/multiple_busses
 
+Model Reference
+===============
+
+* **How the energy system is modelled**: :doc:`Assumption behind the model <model/assumptions>` |:doc:`Available components for modelling <model/components>` | :doc:`Setting constraints on model or components <model/constraints>` | :doc:`Scope and limitation of the model <model/limitations>`
+* **Description of parameters**: :doc:`Input parameters <model/input_parameters>` | :doc:`Output variables and KPIs <model/simulation_outputs>`
+* **Validation of the model**: :doc:`Benchmark tests <model/validation>`
+
+    .. maybe add Pilot projects here as well?
 
 .. toctree::
    :hidden:
@@ -98,6 +106,15 @@ Follow the  :ref:`Quick start guide <installation-steps>`
     contributing (here paste content of contributing.md --> convert to RST and include it as we did for readme, the mention to contributing in getting started will link to this chapter)
 
 
+API Reference
+=============
+
+* **Documentation**: :doc:`Modules and functions <references/code>`
+* **Getting involved**: :doc:`Contributing guidelines and protocols <references/contributing>`
+* **Academic references**: :doc:`Publications <references/publications>` | :doc:`Cite MVS <references/citations>`
+* **Using or modifying MVS**: :doc:`License <references/license>` | :doc:`Cite MVS <references/citations>`
+* **Getting help**: :doc:`Know issues and workaround <references/troubleshooting>` | :doc:`Report a bug or issue <references/bug_report>`
+
 .. toctree::
    :hidden:
    :maxdepth: 1
@@ -113,8 +130,6 @@ Follow the  :ref:`Quick start guide <installation-steps>`
    references/bug_report
 
 
-
-==================
 Indices and tables
 ==================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,21 +8,20 @@
 Multi-vector simulator
 ======================
 
-.. only:: html
-    .. image:: https://readthedocs.org/projects/multi-vector-simulator/badge/?version=latest
-        :target: https://multi-vector-simulator.readthedocs.io/en/latest/?badge=latest
-        :alt: Documentation Status
+.. image:: https://readthedocs.org/projects/multi-vector-simulator/badge/?version=latest
+    :target: https://multi-vector-simulator.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation Status
 
-    .. image:: https://github.com/rl-institut/multi-vector-simulator/workflows/CI/badge.svg
-        :alt: Build status
+.. image:: https://github.com/rl-institut/multi-vector-simulator/workflows/CI/badge.svg
+    :alt: Build status
 
-    .. image:: https://coveralls.io/repos/github/rl-institut/multi-vector-simulator/badge.svg
-        :target: https://coveralls.io/github/rl-institut/multi-vector-simulator
-        :alt: Test coverage
+.. image:: https://coveralls.io/repos/github/rl-institut/multi-vector-simulator/badge.svg
+    :target: https://coveralls.io/github/rl-institut/multi-vector-simulator
+    :alt: Test coverage
 
-    .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4610237.svg
-       :target: https://doi.org/10.5281/zenodo.4610237
-       :alt: Zenodo DOI
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4610237.svg
+   :target: https://doi.org/10.5281/zenodo.4610237
+   :alt: Zenodo DOI
 
 The MVS' global flowchart, or graphical model, is divided into three connected blocks that trace the logic sequence: inputs, system model, and outputs. This is a typical representation of a simulation model.
 
@@ -122,6 +121,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-
-
-

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,3 +1,4 @@
 sphinx>=2.3.1
 sphinx_rtd_theme>=0.4.3
 numpydoc>=1.1.0
+sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
Fix #849 

**Changes proposed in this pull request**:
- Add rsvgconverter in sphinx extenstions to convert badges to pdf
- Cut better chapters for the docs

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
