### PR TITLE
Setup coveralls on github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          coverage run -m pytest tests/ -k "not test_benchmark_kpi" --durations-min=1.0 --durations=400
+          coverage run -m pytest tests/ --durations-min=1.0 --durations=400
 
       - name: Check test coverage
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,3 +66,14 @@ jobs:
         run: |
           coverage run -m pytest tests/ -k "not test_benchmark_kpi" --durations-min=1.0 --durations=400
 
+      - name: Check test coverage
+        run: |
+          coverage report -m
+
+      - name: Report to coveralls
+        run: |
+          coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_SERVICE_NAME: github
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Here is a template for new release sections
 - Readthedocs restructure of chapters (#853, #860)
 - Load svg badges only for html readthedocs (#857) (reversed in #860)
 - Turn docs build warnings into errors (#863)
+- Pytest runs the kpi benchmark tests (which was not the case before) (#864)
 
 
 ### Removed
@@ -80,6 +81,7 @@ Here is a template for new release sections
 - Address issue #825 by changing order of `maximumCap` check and adaption in `C0.process_maximum_cap_constraint()` (#833)
 - Bugfix in `C0.process_maximum_cap_constraint()`: Always set `maximumCap` to `None` in case its value is 0 (#833)
 - ReadTheDocs warnings (#863)
+- Reenable the coverage tests on github actions (#864)
 
 ## [0.5.5] - 2021-03-04
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
 pytest>=5.3.1
 black==19.10b0
 coverage>=4.5
-python-coveralls>=2.9.3
+coveralls>=3.0.1
 mock>=3.0.5


### PR DESCRIPTION
Fix #669 

**Changes proposed in this pull request**:
- Add coveralls call to workflow

The following steps were realized, as well (if applies):
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
