### PR TITLE
Use the badges only for the online RTD not the pdf version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Here is a template for new release sections
 - Replace usage of `maximumCap` in `D1` with `maximumAddCap` calculated in `C0` (#848)
 - Adjust `tests/test_benchmark_feedin.test_benchmark_feedin_tariff_optimize_positive_value()` and `tests/benchmark_test_inputs/Feedin_optimize/csv_elements/energyProduction.csv` to fit new `maximumCap` and `maximumAddCap` definitions (#848)
 - Include new parameter `maximumAddCap` in `tests/test_data/inputs_for_D0/mvs_config.json` and `tests/test_data/inputs_for_D1/mvs_config.json` (#848)
+- Explicitely include badges only for the html version of the RTD and not the pdf (#870)
 
 ### Removed
 - `AUTO_SOURCE` and `AUTO_SINK` as this overcomplicated the labelling process (#837)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,33 +7,34 @@
 
 Multi-vector simulator
 ======================
+.. only:: html
 
-.. image:: https://readthedocs.org/projects/multi-vector-simulator/badge/?version=latest
-    :target: https://multi-vector-simulator.readthedocs.io/en/latest/?badge=latest
-    :alt: Documentation Status
+    .. image:: https://readthedocs.org/projects/multi-vector-simulator/badge/?version=latest
+        :target: https://multi-vector-simulator.readthedocs.io/en/latest/?badge=latest
+        :alt: Documentation Status
 
-.. image:: https://github.com/rl-institut/multi-vector-simulator/workflows/CI/badge.svg
-    :alt: Build status
+    .. image:: https://github.com/rl-institut/multi-vector-simulator/workflows/CI/badge.svg
+        :alt: Build status
 
-.. image:: https://coveralls.io/repos/github/rl-institut/multi-vector-simulator/badge.svg
-    :target: https://coveralls.io/github/rl-institut/multi-vector-simulator
-    :alt: Test coverage
+    .. image:: https://coveralls.io/repos/github/rl-institut/multi-vector-simulator/badge.svg
+        :target: https://coveralls.io/github/rl-institut/multi-vector-simulator
+        :alt: Test coverage
 
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4610237.svg
-    :target: https://doi.org/10.5281/zenodo.4610237
-    :alt: Zenodo DOI
+    .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4610237.svg
+        :target: https://doi.org/10.5281/zenodo.4610237
+        :alt: Zenodo DOI
 
-.. image:: https://img.shields.io/badge/License-GPL%20v2-blue.svg
-    :target: https://img.shields.io/badge/License-GPL%20v2-blue.svg
-    :alt: License gpl2
+    .. image:: https://img.shields.io/badge/License-GPL%20v2-blue.svg
+        :target: https://img.shields.io/badge/License-GPL%20v2-blue.svg
+        :alt: License gpl2
 
-.. image:: https://badge.fury.io/py/multi-vector-simulator.svg
-    :target: https://pypi.org/project/multi-vector-simulator/
-    :alt: Pypi version
+    .. image:: https://badge.fury.io/py/multi-vector-simulator.svg
+        :target: https://pypi.org/project/multi-vector-simulator/
+        :alt: Pypi version
 
-.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-    :target: https://github.com/psf/black
-    :alt: black linter
+    .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+        :target: https://github.com/psf/black
+        :alt: black linter
 
 The MVS' global flowchart, or graphical model, is divided into three connected blocks that trace the logic sequence: inputs, system model, and outputs. This is a typical representation of a simulation model.
 


### PR DESCRIPTION
**Changes proposed in this pull request**:
- Fix latex build due to svg badges by explicitely not including badges in pdf version of RTD

The following steps were realized, as well (if applies):
- [x] Update the CHANGELOG.md


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
