### PR TITLE
Prevent github action workflow for changes on docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,10 @@ name: CI
 # events but only for the dev and master branches
 on:
   push:
-
+    paths-ignore:
+      - 'docs/**'
+      - 'CHANGELOG.md'
+      - 'README.rst'
   pull_request:
     branches: 
       -dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Here is a template for new release sections
 - Change `E1.add_info_flows()` so that storage peculiarities for the information is considered (#859)
 - Benchmark tests for `AE-Grid-Battery`: Input files and pytests (#859)
 - `E1.lcoe_assets` to calculate LCOE of storage capacity throughput based on input flow. Required change of `test_benchmark_KPI` (storage not used, LCOE=0) (#589)
+- Modified github action workflow so that it is not triggered when one modifies the README, CHANGELOG or the docs (#872)
 
 ### Removed
 - `AUTO_SOURCE` and `AUTO_SINK` as this overcomplicated the labelling process (#837)


### PR DESCRIPTION
It should prevent to have to wait for the test on the .py and coverage to pass if we change only the documentation .rst files
Leading to less waiting time and avoid using githubaction servers for nothing


**Changes proposed in this pull request**:
- Your_changes

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [ ] Update the CHANGELOG.md
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
