### PR TITLE
Print objective value in simulation output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,16 +22,17 @@ Here is a template for new release sections
 ## [Unreleased]
 
 ### Added
--
+- Benchmark test (`tests/benchmark_test_inputs/objective_value_exception_equal_annuity`) for in `F0_output.parse_simulation_log` and data stored to `SIMULATION_RESULTS` as well as `OBJECTIVE_VALUE` (#901)
+- Constants `BENCHMARK_TEST_INPUT_FOLDER` and `BENCHMARK_TEST_OUTPUT_FOLDER` in `tests/_constants.py` (#901)
 
 ### Changed
--
+- `F0_output.parse_simulation_log`, so that `SIMULATION_RESULTS` are not overwritten anymore (#901)
 
 ### Removed
 -
 
 ### Fixed
--
+- `OBJECTIVE_VALUE`, `SIMULTATION_TIME`, `MODELLING_TIME` now included in the `json_with_results.json` (#901)
 
 ## [1.0.0] - 2021-05-31
 

--- a/src/multi_vector_simulator/F0_output.py
+++ b/src/multi_vector_simulator/F0_output.py
@@ -231,6 +231,11 @@ def parse_simulation_log(path_log_file, dict_values):
     -------
     Updates the results dictionary with the log messages of the simulation
 
+    Notes
+    -----
+    This function is tested with:
+    - test_F0_output.TestLogCreation.test_parse_simulation_log
+
     """
     # Dictionaries to gather non-fatal warning and error messages that appear during the simulation
 
@@ -259,7 +264,7 @@ def parse_simulation_log(path_log_file, dict_values):
 
     log_dict = {ERRORS: error_dict, WARNINGS: warning_dict}
 
-    dict_values.update({SIMULATION_RESULTS: {LOGS: log_dict}})
+    dict_values[SIMULATION_RESULTS].update({LOGS: log_dict})
 
 
 def store_as_json(dict_values, output_folder=None, file_name=None):

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -17,3 +17,9 @@ JSON_CSV_PATH = os.path.join(TEST_REPO_PATH, INPUT_FOLDER, CSV_ELEMENTS, CSV_FNA
 
 # folder to store input directory for tests
 TEST_INPUT_DIRECTORY = "test_data"
+
+# Folder for all benchmark test inputs:
+BENCHMARK_TEST_INPUT_FOLDER = "benchmark_test_inputs"
+
+# Folder for benchmark test outputs:
+BENCHMARK_TEST_OUTPUT_FOLDER = "benchmark_test_outputs"

--- a/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/constraints.csv
+++ b/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/constraints.csv
@@ -1,0 +1,5 @@
+,unit,constraints
+minimal_renewable_factor,factor,0
+maximum_emissions,kgCO2eq/a,None
+minimal_degree_of_autonomy,factor,0
+net_zero_energy,bool,False

--- a/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/economic_data.csv
+++ b/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/economic_data.csv
@@ -1,0 +1,5 @@
+,unit,economic_data
+project_duration,year,30
+currency,str,EUR
+discount_factor,factor,0.08
+tax,factor,0.0 

--- a/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/energyBusses.csv
+++ b/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/energyBusses.csv
@@ -1,0 +1,3 @@
+,unit,Electricity,Electricity (DSO)
+energyVector,str,Electricity,Electricity
+

--- a/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/energyConsumption.csv
+++ b/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/energyConsumption.csv
@@ -1,0 +1,8 @@
+,unit,demand_01
+dsm,str,False
+file_name,str,demand.csv
+type_asset,str,demand
+type_oemof,str,sink
+energyVector,str,Electricity
+inflow_direction,str,Electricity
+unit,str,kW

--- a/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/energyConversion.csv
+++ b/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/energyConversion.csv
@@ -1,0 +1,16 @@
+,unit,transformer_station_in
+age_installed,year,0
+development_costs,currency,0
+specific_costs,currency/kW,0
+efficiency,factor,0.96
+inflow_direction,str,Electricity (DSO)
+installedCap,kW,0
+maximumCap,kW,None
+lifetime,year,30
+specific_costs_om,currency/kW/year,0
+dispatch_price,currency/kWh,0
+optimizeCap,bool,True
+outflow_direction,str,Electricity
+energyVector,str,Electricity
+type_oemof,str,transformer
+unit,str,kVA

--- a/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/energyProduction.csv
+++ b/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/energyProduction.csv
@@ -1,0 +1,17 @@
+,unit,pv_plant_01
+age_installed,year,0
+development_costs,currency,0
+specific_costs,currency/unit,1000
+file_name,str,pv_solar_input.csv
+installedCap,kWp,0
+maximumCap, kWp,None
+lifetime,year,30
+specific_costs_om,currency/unit/year,0
+dispatch_price,currency/kWh,0
+optimizeCap,bool,True
+outflow_direction,str,Electricity
+type_oemof,str,source
+unit,str,kWp
+energyVector,str,Electricity
+renewableAsset,bool,True
+emission_factor,kgCO2eq/unit,0

--- a/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/energyProviders.csv
+++ b/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/energyProviders.csv
@@ -1,0 +1,13 @@
+,unit,Electricity_grid_DSO
+unit,str,kW
+energy_price,currency/kWh,0.17
+feedin_tariff,currency/kWh,0.04
+inflow_direction,str,Electricity (DSO)
+optimizeCap,bool,True
+outflow_direction,str,Electricity (DSO)
+peak_demand_pricing,currency/kW,0
+peak_demand_pricing_period,"times per year (1,2,3,4,6,12)",1
+type_oemof,str,source
+energyVector,str,Electricity
+emission_factor,kgCO2eq/kWh,0.019
+renewable_share,factor,0

--- a/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/energyStorage.csv
+++ b/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/energyStorage.csv
@@ -1,0 +1,8 @@
+,unit
+inflow_direction,str
+label,str
+optimizeCap,bool
+outflow_direction,str
+type_oemof,str
+storage_filename,str
+energyVector,str

--- a/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/fixcost.csv
+++ b/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/fixcost.csv
@@ -1,0 +1,6 @@
+,unit
+age_installed,year
+development_costs,currency
+specific_costs,currency
+lifetime,year
+specific_costs_om,currency/year

--- a/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/project_data.csv
+++ b/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/project_data.csv
@@ -1,0 +1,9 @@
+,unit,project_data
+country,str,NA
+latitude,str,0
+longitude,str,0
+project_id,str,1
+project_name,str,Benchmark test for simple case electricity bus
+scenario_id,str,2
+scenario_name,str,Objective value benchmark test
+scenario_description,str,"Benchmark test with the exception that the objective value is equal to the total annuity of the system. This is only possible when `evaluated_period==365` in `simulation settings`, when there are no entries in `fix_costs.csv` and when `development_costs==0` as well as `installed_cap==0` for all assets."

--- a/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/simulation_settings.csv
+++ b/tests/benchmark_test_inputs/objective_value_exception_equal_annuity_total/csv_elements/simulation_settings.csv
@@ -1,0 +1,5 @@
+,unit,simulation_settings
+evaluated_period,days,365
+output_lp_file,bool,True
+start_date,str,2018-01-01 00:00:00
+timestep,minutes,60

--- a/tests/test_A1_csv_to_json.py
+++ b/tests/test_A1_csv_to_json.py
@@ -51,6 +51,8 @@ from _constants import (
     PATHS_TO_PLOTS,
     TYPE_BOOL,
     TEST_REPO_PATH,
+    BENCHMARK_TEST_INPUT_FOLDER,
+    BENCHMARK_TEST_OUTPUT_FOLDER,
 )
 
 CSV_PARAMETERS = ["param1", "param2"]
@@ -377,7 +379,7 @@ def test_default_values_storage_without_thermal_losses():
 
     data_path = os.path.join(
         TEST_REPO_PATH,
-        "benchmark_test_inputs",
+        BENCHMARK_TEST_INPUT_FOLDER,
         "Feature_stratified_thermal_storage",
         "csv_elements",
     )
@@ -411,7 +413,7 @@ def test_default_values_storage_with_thermal_losses():
 
     data_path = os.path.join(
         TEST_REPO_PATH,
-        "benchmark_test_inputs",
+        BENCHMARK_TEST_INPUT_FOLDER,
         "Feature_stratified_thermal_storage",
         "csv_elements",
     )

--- a/tests/test_C1_verification.py
+++ b/tests/test_C1_verification.py
@@ -852,6 +852,8 @@ import argparse
 from _constants import (
     TEST_REPO_PATH,
     CSV_EXT,
+    BENCHMARK_TEST_INPUT_FOLDER,
+    BENCHMARK_TEST_OUTPUT_FOLDER,
 )
 from multi_vector_simulator.utils.constants import LOGFILE
 
@@ -859,8 +861,8 @@ from multi_vector_simulator.utils.constants import LOGFILE
 @mock.patch("argparse.ArgumentParser.parse_args", return_value=argparse.Namespace())
 def test_check_energy_system_can_fulfill_max_demand_fails_mvs_runthrough(caplog):
     """This test makes sure that the C1.check_energy_system_can_fulfill_max_demand not only works as a function, but as an integrated function of the MVS model, as it is dependent on a lot of pre-processing steps where things in the future may be changed."""
-    TEST_INPUT_PATH = os.path.join(TEST_REPO_PATH, "benchmark_test_inputs")
-    TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, "benchmark_test_outputs")
+    TEST_INPUT_PATH = os.path.join(TEST_REPO_PATH, BENCHMARK_TEST_INPUT_FOLDER)
+    TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, BENCHMARK_TEST_OUTPUT_FOLDER)
     if os.path.exists(TEST_OUTPUT_PATH):
         shutil.rmtree(TEST_OUTPUT_PATH, ignore_errors=True)
     with pytest.raises(MVSOemofError):

--- a/tests/test_F0_output.py
+++ b/tests/test_F0_output.py
@@ -23,7 +23,7 @@ import multi_vector_simulator.B0_data_input_json as B0
 import multi_vector_simulator.F0_output as F0
 from multi_vector_simulator.cli import main
 
-from multi_vector_simulator.utils.constants import JSON_WITH_RESULTS
+from multi_vector_simulator.utils.constants import JSON_WITH_RESULTS, CSV_EXT
 
 from multi_vector_simulator.utils.constants_json_strings import (
     PROJECT_DATA,
@@ -57,6 +57,7 @@ from _constants import (
     TYPE_STR,
     PATH_OUTPUT_FOLDER,
     START_DATE,
+    BENCHMARK_TEST_INPUT_FOLDER,
 )
 
 PARSER = initializing.mvs_arg_parser()
@@ -220,7 +221,7 @@ class TestLogCreation:
             shutil.rmtree(OUTPUT_PATH, ignore_errors=True)
 
     test = "objective_value_exception_equal_annuity_total"
-    test_folder = os.path.join("tests", "benchmark_test_inputs", test)
+    test_folder = os.path.join("tests", BENCHMARK_TEST_INPUT_FOLDER, test)
 
     @pytest.mark.skipif(
         EXECUTE_TESTS_ON not in (TESTS_ON_MASTER),
@@ -230,7 +231,17 @@ class TestLogCreation:
     @mock.patch(
         "argparse.ArgumentParser.parse_args",
         return_value=PARSER.parse_args(
-            ["-f", "-log", "warning", "-o", OUTPUT_PATH, "-i", test_folder, "-ext", "csv"]
+            [
+                "-f",
+                "-log",
+                "warning",
+                "-o",
+                OUTPUT_PATH,
+                "-i",
+                test_folder,
+                "-ext",
+                CSV_EXT,
+            ]
         ),
     )
     def test_parse_simulation_log(self, m_args):

--- a/tests/test_F0_output.py
+++ b/tests/test_F0_output.py
@@ -22,16 +22,27 @@ import multi_vector_simulator.A0_initialization as initializing
 import multi_vector_simulator.B0_data_input_json as B0
 import multi_vector_simulator.F0_output as F0
 from multi_vector_simulator.cli import main
+
+from multi_vector_simulator.utils.constants import JSON_WITH_RESULTS
+
 from multi_vector_simulator.utils.constants_json_strings import (
     PROJECT_DATA,
     SIMULATION_SETTINGS,
     PROJECT_NAME,
     SCENARIO_NAME,
     KPI,
+    KPI_SCALARS_DICT,
+    ANNUITY_TOTAL,
     OPTIMIZED_FLOWS,
+    SIMULATION_RESULTS,
+    LOGS,
+    OBJECTIVE_VALUE,
+    SIMULTATION_TIME,
+    MODELLING_TIME,
 )
 from _constants import (
     EXECUTE_TESTS_ON,
+    TESTS_ON_MASTER,
     TEST_REPO_PATH,
     DICT_PLOTS,
     PDF_REPORT,
@@ -195,6 +206,64 @@ class TestPDFReportCreation:
         """Run the simulation with -pdf option to make sure the pdf file is generated """
         main()
         assert os.path.exists(os.path.join(OUTPUT_PATH, PDF_REPORT)) is True
+
+    def teardown_method(self):
+        """ """
+        if os.path.exists(OUTPUT_PATH):
+            shutil.rmtree(OUTPUT_PATH, ignore_errors=True)
+
+
+class TestLogCreation:
+    def setup_method(self):
+        """ """
+        if os.path.exists(OUTPUT_PATH):
+            shutil.rmtree(OUTPUT_PATH, ignore_errors=True)
+
+    test = "objective_value_exception_equal_annuity_total"
+    test_folder = os.path.join("tests", "benchmark_test_inputs", test)
+
+    @pytest.mark.skipif(
+        EXECUTE_TESTS_ON not in (TESTS_ON_MASTER),
+        reason="Benchmark test deactivated, set env variable "
+        "EXECUTE_TESTS_ON to 'master' to run this test",
+    )
+    @mock.patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=PARSER.parse_args(
+            ["-f", "-log", "warning", "-o", OUTPUT_PATH, "-i", test_folder, "-ext", "csv"]
+        ),
+    )
+    def test_parse_simulation_log(self, m_args):
+        main()
+        json_with_results = B0.load_json(
+            os.path.join(OUTPUT_PATH, JSON_WITH_RESULTS + ".json"),
+            flag_missing_values=False,
+        )
+        print(json_with_results[SIMULATION_RESULTS])
+        assert (
+            SIMULATION_RESULTS in json_with_results
+        ), f"There should be a subcategory {SIMULATION_RESULTS} in the output json file, including amongst others the objective value and the log messages. {SIMULATION_RESULTS} is missing."
+        assert (
+            LOGS in json_with_results[SIMULATION_RESULTS]
+        ), f"In {SIMULATION_RESULTS} of the json results, the log messages should be compiled."
+        for result in [OBJECTIVE_VALUE, SIMULTATION_TIME, MODELLING_TIME]:
+            assert (
+                result in json_with_results[SIMULATION_RESULTS]
+            ), f"The result {result} is not included in the output json file in category {SIMULATION_RESULTS}."
+        assert (
+            KPI in json_with_results
+        ), f"Subcategory {KPI} should be in json result file."
+        assert (
+            KPI_SCALARS_DICT in json_with_results[KPI]
+        ), f"{KPI_SCALARS_DICT} should be in subcategory {KPI} of the json result file."
+        assert (
+            ANNUITY_TOTAL in json_with_results[KPI][KPI_SCALARS_DICT]
+        ), f"{ANNUITY_TOTAL} should be in {KPI_SCALARS_DICT}, subcategory {KPI} of the json result file."
+        obj = json_with_results[SIMULATION_RESULTS][OBJECTIVE_VALUE]
+        annuity_total = json_with_results[KPI][KPI_SCALARS_DICT][ANNUITY_TOTAL]
+        assert pytest.approx(
+            annuity_total == obj, rel=1e-3
+        ), f"The {OBJECTIVE_VALUE} ({obj}) should be equal to the {ANNUITY_TOTAL} ({annuity_total}) in this specific case."
 
     def teardown_method(self):
         """ """

--- a/tests/test_F0_output.py
+++ b/tests/test_F0_output.py
@@ -250,7 +250,6 @@ class TestLogCreation:
             os.path.join(OUTPUT_PATH, JSON_WITH_RESULTS + ".json"),
             flag_missing_values=False,
         )
-        print(json_with_results[SIMULATION_RESULTS])
         assert (
             SIMULATION_RESULTS in json_with_results
         ), f"There should be a subcategory {SIMULATION_RESULTS} in the output json file, including amongst others the objective value and the log messages. {SIMULATION_RESULTS} is missing."

--- a/tests/test_benchmark_KPI.py
+++ b/tests/test_benchmark_KPI.py
@@ -24,6 +24,8 @@ from _constants import (
     TEST_REPO_PATH,
     CSV_EXT,
     TIME_SERIES,
+    BENCHMARK_TEST_INPUT_FOLDER,
+    BENCHMARK_TEST_OUTPUT_FOLDER,
 )
 
 from multi_vector_simulator.utils.constants import (
@@ -84,8 +86,8 @@ from multi_vector_simulator.utils.constants_json_strings import (
     DSO_CONSUMPTION,
 )
 
-TEST_INPUT_PATH = os.path.join(TEST_REPO_PATH, "benchmark_test_inputs")
-TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, "benchmark_test_outputs")
+TEST_INPUT_PATH = os.path.join(TEST_REPO_PATH, BENCHMARK_TEST_INPUT_FOLDER)
+TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, BENCHMARK_TEST_OUTPUT_FOLDER)
 
 DICT_ECONOMIC = {
     CURR: "Euro",

--- a/tests/test_benchmark_constraints.py
+++ b/tests/test_benchmark_constraints.py
@@ -20,6 +20,8 @@ from _constants import (
     TESTS_ON_MASTER,
     TEST_REPO_PATH,
     CSV_EXT,
+    BENCHMARK_TEST_INPUT_FOLDER,
+    BENCHMARK_TEST_OUTPUT_FOLDER,
 )
 
 from multi_vector_simulator.utils.constants import (
@@ -58,8 +60,8 @@ from multi_vector_simulator.utils.constants_json_strings import (
     FILENAME,
 )
 
-TEST_INPUT_PATH = os.path.join(TEST_REPO_PATH, "benchmark_test_inputs")
-TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, "benchmark_test_outputs")
+TEST_INPUT_PATH = os.path.join(TEST_REPO_PATH, BENCHMARK_TEST_INPUT_FOLDER)
+TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, BENCHMARK_TEST_OUTPUT_FOLDER)
 
 
 class Test_Constraints:

--- a/tests/test_benchmark_feedin.py
+++ b/tests/test_benchmark_feedin.py
@@ -20,6 +20,8 @@ from _constants import (
     OPTIMIZED_ADD_CAP,
     LABEL,
     CSV_ELEMENTS,
+    BENCHMARK_TEST_OUTPUT_FOLDER,
+    BENCHMARK_TEST_INPUT_FOLDER,
 )
 
 from multi_vector_simulator.utils.constants import (
@@ -50,8 +52,8 @@ from multi_vector_simulator.utils.constants_json_strings import (
     EXCESS_SINK,
 )
 
-TEST_INPUT_PATH = os.path.join(TEST_REPO_PATH, "benchmark_test_inputs")
-TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, "benchmark_test_outputs")
+TEST_INPUT_PATH = os.path.join(TEST_REPO_PATH, BENCHMARK_TEST_INPUT_FOLDER)
+TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, BENCHMARK_TEST_OUTPUT_FOLDER)
 
 FEEDIN = f"DSO{DSO_FEEDIN}"
 CONSUMPTION = f"DSO{DSO_CONSUMPTION}"

--- a/tests/test_benchmark_scenarios.py
+++ b/tests/test_benchmark_scenarios.py
@@ -24,6 +24,8 @@ from _constants import (
     EXECUTE_TESTS_ON,
     TESTS_ON_MASTER,
     TEST_REPO_PATH,
+    BENCHMARK_TEST_INPUT_FOLDER,
+    BENCHMARK_TEST_OUTPUT_FOLDER,
     CSV_EXT,
 )
 
@@ -61,8 +63,8 @@ from multi_vector_simulator.utils.constants_json_strings import (
 from multi_vector_simulator.utils.data_parser import convert_epa_params_to_mvs
 
 
-TEST_INPUT_PATH = os.path.join(TEST_REPO_PATH, "benchmark_test_inputs")
-TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, "benchmark_test_outputs")
+TEST_INPUT_PATH = os.path.join(TEST_REPO_PATH, BENCHMARK_TEST_INPUT_FOLDER)
+TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, BENCHMARK_TEST_OUTPUT_FOLDER)
 
 
 class TestACElectricityBus:

--- a/tests/test_benchmark_special_features.py
+++ b/tests/test_benchmark_special_features.py
@@ -14,6 +14,8 @@ from _constants import (
     TESTS_ON_MASTER,
     TEST_REPO_PATH,
     CSV_EXT,
+    BENCHMARK_TEST_OUTPUT_FOLDER,
+    BENCHMARK_TEST_INPUT_FOLDER,
 )
 from multi_vector_simulator.utils.constants import (
     JSON_WITH_RESULTS,
@@ -39,8 +41,8 @@ from multi_vector_simulator.utils.constants_json_strings import (
     TIMESERIES,
 )
 
-TEST_INPUT_PATH = os.path.join(TEST_REPO_PATH, "benchmark_test_inputs")
-TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, "benchmark_test_outputs")
+TEST_INPUT_PATH = os.path.join(TEST_REPO_PATH, BENCHMARK_TEST_INPUT_FOLDER)
+TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, BENCHMARK_TEST_OUTPUT_FOLDER)
 
 
 class Test_Parameter_Parsing:

--- a/tests/test_benchmark_stratified_thermal_storage.py
+++ b/tests/test_benchmark_stratified_thermal_storage.py
@@ -23,6 +23,8 @@ from _constants import (
     TESTS_ON_MASTER,
     TEST_REPO_PATH,
     CSV_EXT,
+    BENCHMARK_TEST_OUTPUT_FOLDER,
+    BENCHMARK_TEST_INPUT_FOLDER,
 )
 
 from multi_vector_simulator.utils.constants_json_strings import (
@@ -32,9 +34,9 @@ from multi_vector_simulator.utils.constants_json_strings import (
 )
 
 TEST_INPUT_PATH = os.path.join(
-    TEST_REPO_PATH, "benchmark_test_inputs", "Feature_stratified_thermal_storage"
+    TEST_REPO_PATH, BENCHMARK_TEST_INPUT_FOLDER, "Feature_stratified_thermal_storage"
 )
-TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, "benchmark_test_outputs")
+TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, BENCHMARK_TEST_OUTPUT_FOLDER)
 
 
 class TestStratifiedThermalStorage:


### PR DESCRIPTION
Fix #900

**Changes proposed in this pull request**:
- Add simulation inputs for `tests/inputs/objective_value_exception_equal_annuity_total`
- Add pytest for `F0.TestLogCreation.test_parse_simulation_log` and benchmark test of `OBJECTIVE_VALUE`
- Fix `F0.TestLogCreation.test_parse_simulation_log`
- Constants `BENCHMARK_TEST_INPUT_FOLDER` and `BENCHMARK_TEST_OUTPUT_FOLDER` in `tests/_constants.py` (#901)

The following steps were realized, as well (if applies):
:x: Use in-line comments to explain your code
:x: Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
:x: For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)