### PR TITLE
Test and fix multiple inflows/outflows for energyConversion assets

### DIFF
--- a/docs/examples/multiple_busses.rst
+++ b/docs/examples/multiple_busses.rst
@@ -3,26 +3,44 @@
 Using multiple in- or output busses
 ###################################
 
-Sometimes, you may also want to have multiple input- our output busses connected to a component.
+Sometimes, you may want to have multiple input- our output busses connected to an energy conversion asset.
 This is for example the case if you want to implement an electrolyzer with a transformer,
 and want to track water consumption at the same time as you want to track electricity consumption.
 
 You can define this, again, in the csv´s.
 Here, you would insert a list of your parameters instead of the scalar value of a parameter:
 
-    [0.99, 0.98]
+    "[0.99, 0.98]"
 
-Would be an example of a transformer with two efficiencies.
+The apostrophes are necessary to also input in your csv, as otherwise the comma might be interpreted as a cell seperator and destroy your csv formatting.
+This could be an example of a transformer with two efficiencies.
 
 You can also wrap multiple inputs/outputs with scalars that are defined as efficiencies.
 For that, you define one or multiple of the parameters within the list with the above introduced dictionary:
 
-    [0.99, {'value': {'file_name': 'your_file_name.csv', 'header': 'your_header'}, 'unit': 'your_unit'}]
+    "[0.99, {'value': {'file_name': 'your_file_name.csv', 'header': 'your_header'}, 'unit': 'your_unit'}]"
 
-If you define an output- or input flow with with a list,
-you also have to define related parameters as a list.
-So, for example, if you define the input direction as a list for an energyConsumption asset,
-you need to define the efficiencies and dispatch_price costs as a list as well.
+.. warning::
+    If you define an output- or input flow with with a list, you also have to define related parameters as a list.
+
+If you are defining the :ref:`inflow_direction <inflowdirection-label>` as a list, you must also define
+
+- The :ref:`efficiency <efficiency-label>`: The efficiency then defines the ratio of the two input flows to generate the output flow.
+
+If you are defining the :ref:`outflow_direction <outflowdirection-label>` as a list, you must also define
+
+- The :ref:`efficiency <efficiency-label>`: The efficiency then defines the ratio of the input flow and the specific produced output flow.
+
+- The :ref:`dispatch_price <dispatchprice-label>` relative to the subsequent output flows
+
+- The :ref:`energyVector <energyvector-label>` according to the energyVector of the subsequent output flows.
+
+.. warning::
+
+    You can not have multiple inflow and outflow directions at the same time!
+
+.. note::
+    The appropriateness of inputs is tested with :func:`C1.check_if_that_no_parameters_are_defined_as_lists_for_assets_where_it_is_not_allowed() <multi_vector_simulator.C1_verification.check_if_that_no_parameters_are_defined_as_lists_for_assets_where_it_is_not_allowed>` and :func:`C1.check_if_all_parameters_for_multiple_inflow_outflow_directions_are_provided() <multi_vector_simulator.C1_verification.check_if_all_parameters_for_multiple_inflow_outflow_directions_are_provided>`.
 
 You can see an implemented example here, where the heat pump has a time-dependent efficiency:
 

--- a/docs/simulating_with_the_mvs.rst
+++ b/docs/simulating_with_the_mvs.rst
@@ -173,7 +173,7 @@ The information fed into the MVS via the CSV's would therefore define following 
 Ideally you sketch down the energy system you want to simulate with the above-mentioned granularity
 and only using sources, sinks, transformers and buses (meaning the oemof components).
 When interconnecting different assets make sure that you use the correct bus name in each of the CSV input files.
-The bus names are defined with :code:`input_direction` and :code:`output_direction`.
+The bus names are defined with :code:`inflow_direction` and :code:`outflow_direction`.
 If you interconnect your assets or buses incorrectly the system will still be built but the simulation terminated.
 When executing a simulation, the MVS will generate a rough graphic visualisation of your energy system if you use the option :code:`-png`.
 

--- a/src/multi_vector_simulator/A1_csv_to_json.py
+++ b/src/multi_vector_simulator/A1_csv_to_json.py
@@ -489,7 +489,7 @@ def create_json_from_csv(
                         else:
                             column_dict.update({param: value_list})
                         logging.info(
-                            f"Parameter {param} of asset {column} is defined as a list."
+                            f"Parameter {param} of asset {column} is defined as a list: {value_list}"
                         )
                 else:
                     column_dict = conversion(

--- a/src/multi_vector_simulator/C0_data_processing.py
+++ b/src/multi_vector_simulator/C0_data_processing.py
@@ -63,7 +63,15 @@ def all(dict_values):
     B0.retrieve_date_time_info(dict_values[SIMULATION_SETTINGS])
     add_economic_parameters(dict_values[ECONOMIC_DATA])
     define_energy_vectors_from_busses(dict_values)
+
+    # Run validity checks on input data
     C1.check_if_energy_vector_of_all_assets_is_valid(dict_values)
+    C1.check_if_that_no_parameters_are_defined_as_lists_for_assets_where_it_is_not_allowed(
+        dict_values
+    )
+    C1.check_if_all_parameters_for_multiple_inflow_outflow_directions_are_provided(
+        dict_values
+    )
 
     ## Verify inputs
     # todo check whether input values can be true

--- a/src/multi_vector_simulator/C0_data_processing.py
+++ b/src/multi_vector_simulator/C0_data_processing.py
@@ -583,6 +583,7 @@ def add_asset_to_asset_dict_for_each_flow_direction(dict_values, dict_asset, ass
     -----
     Tested with:
     - C0.test_add_asset_to_asset_dict_for_each_flow_direction()
+    - C0.test_add_asset_to_asset_dict_for_each_flow_direction_multiple_output_and_input_flows()
     """
 
     # The asset needs to be added both to the inflow as well as the outflow bus:

--- a/tests/benchmark_test_inputs/Feature_output_flows_as_list/csv_elements/energyConsumption.csv
+++ b/tests/benchmark_test_inputs/Feature_output_flows_as_list/csv_elements/energyConsumption.csv
@@ -1,7 +1,5 @@
 ,unit,demand_01,demand_02
-dsm,str,False,False
 file_name,str,demand.csv,demand.csv
-type_asset,str,demand,demand
 type_oemof,str,sink,sink
 energyVector,str,Electricity,Heat
 inflow_direction,str,Electricity,Heat

--- a/tests/benchmark_test_inputs/Feature_output_flows_as_list/csv_elements/energyConversion.csv
+++ b/tests/benchmark_test_inputs/Feature_output_flows_as_list/csv_elements/energyConversion.csv
@@ -7,7 +7,7 @@ inflow_direction,str,Electricity
 installedCap,kW,1250
 lifetime,year,30
 specific_costs_om,currency/kW/year,5
-dispatch_price,currency/kWh,0.5
+dispatch_price,currency/kWh,"[0,0]"
 optimizeCap,bool,False
 outflow_direction,str,"[Electricity, Heat]"
 energyVector,str,Electricity

--- a/tests/benchmark_test_inputs/Feature_output_flows_as_list/csv_elements/energyConversion.csv
+++ b/tests/benchmark_test_inputs/Feature_output_flows_as_list/csv_elements/energyConversion.csv
@@ -9,7 +9,7 @@ lifetime,year,30
 specific_costs_om,currency/kW/year,5
 dispatch_price,currency/kWh,0.5
 optimizeCap,bool,False
-outflow_direction,str,"['Electricity', 'Heat`]"
+outflow_direction,str,"[Electricity, Heat]"
 energyVector,str,Electricity
 type_oemof,str,transformer
 unit,str,kVA

--- a/tests/benchmark_test_inputs/Feature_output_flows_as_list/csv_elements/energyProduction.csv
+++ b/tests/benchmark_test_inputs/Feature_output_flows_as_list/csv_elements/energyProduction.csv
@@ -9,7 +9,7 @@ lifetime,year,20
 specific_costs_om,currency/unit/year,0
 dispatch_price,currency/kWh,0.1
 optimizeCap,bool,True
-outflow_direction,str,Electricity (diesel)
+outflow_direction,str,Electricity
 type_oemof,str,source
 unit,str,kWh_chem
 energyVector,str,Electricity

--- a/tests/benchmark_test_inputs/Feature_output_flows_as_list/csv_elements/project_data.csv
+++ b/tests/benchmark_test_inputs/Feature_output_flows_as_list/csv_elements/project_data.csv
@@ -1,9 +1,9 @@
 ,unit,project_data
-country,str,NA
+country,str,Somewhere
 latitude,str,0
 longitude,str,0
 project_id,str,1
 project_name,str,Benchmark test for simple electricity bus
 scenario_id,str,2
 scenario_name,str,A+D
-scenario_description,str,""
+scenario_description,str,Description

--- a/tests/test_C0_data_processing.py
+++ b/tests/test_C0_data_processing.py
@@ -407,6 +407,40 @@ def test_add_asset_to_asset_dict_for_each_flow_direction():
         ), f"The asset label of asset {asset_name} in the asset list of {bus} is of unexpected value."
 
 
+def test_add_asset_to_asset_dict_for_each_flow_direction_multiple_output_and_input_flows():
+    bus_names = ["bus_name_" + str(i) for i in range(1, 5)]
+    asset_name = "asset"
+    asset_label = "asset_label"
+    energy_vector = "Electricity"
+    dict_test = {
+        ENERGY_BUSSES: {
+            bus_names[0]: {LABEL: bus_names[0], ENERGY_VECTOR: energy_vector},
+            bus_names[1]: {LABEL: bus_names[1], ENERGY_VECTOR: energy_vector},
+            bus_names[2]: {LABEL: bus_names[2], ENERGY_VECTOR: energy_vector},
+            bus_names[3]: {LABEL: bus_names[3], ENERGY_VECTOR: energy_vector},
+        },
+        ENERGY_CONVERSION: {
+            asset_name: {
+                LABEL: asset_label,
+                OUTFLOW_DIRECTION: [bus_names[0], bus_names[1]],
+                INFLOW_DIRECTION: [bus_names[2], bus_names[3]],
+                ENERGY_VECTOR: energy_vector,
+            }
+        },
+    }
+    C0.add_asset_to_asset_dict_for_each_flow_direction(
+        dict_test, dict_test[ENERGY_CONVERSION][asset_name], asset_name
+    )
+
+    for bus in bus_names:
+        assert (
+            asset_name in dict_test[ENERGY_BUSSES][bus][ASSET_DICT]
+        ), f"The asset {asset_name} is not added to the list of assets attached to the bus {bus}."
+        assert (
+            dict_test[ENERGY_BUSSES][bus][ASSET_DICT][asset_name] == asset_label
+        ), f"The asset {asset_name} is not added with its {LABEL} to the list of assets attached to the bus."
+
+
 def test_add_asset_to_asset_dict_of_bus_ValueError():
     bus_name = "bus_name"
     asset_name = "asset"

--- a/tests/test_D1_model_components.py
+++ b/tests/test_D1_model_components.py
@@ -224,7 +224,7 @@ class TestTransformerComponent:
             optimize=True, dict_asset=dict_asset, multiple_outputs=True
         )
 
-    def test_transformer_fix_cap_single_busses(self):
+    def test_transformer_constant_efficiency_fix_single_busses(self):
         dict_asset = self.dict_values[ENERGY_CONVERSION][
             "transformer_fix_single_busses"
         ]
@@ -249,7 +249,7 @@ class TestTransformerComponent:
             optimize=False, dict_asset=dict_asset
         )
 
-    def test_transformer_fix_cap_multiple_input_busses(self,):
+    def test_transformer_constant_efficiency_fix_multiple_input_busses(self,):
         dict_asset = self.dict_values[ENERGY_CONVERSION][
             "transformer_fix_multiple_input_busses"
         ]
@@ -274,7 +274,7 @@ class TestTransformerComponent:
             optimize=False, dict_asset=dict_asset
         )
 
-    def test_transformer_fix_cap_multiple_output_busses(self):
+    def test_transformer_constant_efficiency_fix_multiple_output_busses(self):
         dict_asset = self.dict_values[ENERGY_CONVERSION][
             "transformer_fix_multiple_output_busses"
         ]
@@ -298,6 +298,21 @@ class TestTransformerComponent:
         self.helper_test_transformer_in_model_and_dict(
             optimize=False, dict_asset=dict_asset, multiple_outputs=True
         )
+
+    def test_transformer_constant_efficiency_fix_multiple_input_busses_and_output_busses(
+        self,
+    ):
+        dict_asset = self.dict_values[ENERGY_CONVERSION][
+            "transformer_fix_multiple_input_busses_multiple_output_busses"
+        ]
+
+        with pytest.raises(ValueError):
+            D1.transformer(
+                model=self.model,
+                dict_asset=dict_asset,
+                transformer=self.transformers,
+                bus=self.busses,
+            )
 
 
 class TestSinkComponent:

--- a/tests/test_data/inputs_for_D1/mvs_config.json
+++ b/tests/test_data/inputs_for_D1/mvs_config.json
@@ -241,7 +241,7 @@
         "transformer_fix_multiple_input_busses": {
             "efficiency": {
                 "unit": "factor",
-                "value": 0.33
+                "value": [0.33, 0.33]
             },
             "installedCap": {
                 "unit": "kW",
@@ -288,6 +288,32 @@
                 "unit": "currency/unit/simulation period"},
             "type_oemof": "transformer"
         },
+        "transformer_fix_multiple_input_busses_multiple_output_busses": {
+            "efficiency": {
+                "unit": "factor",
+                "value": [0.33, 0.33]
+            },
+            "installedCap": {
+                "unit": "kW",
+                "value": 10
+            },
+            "inflow_direction": ["Heat bus","Electricity bus"],
+            "label": "Transformer fix multiple output busses multiple input busses",
+            "dispatch_price": {
+                "unit": "currency/kWh",
+                "value": [0, 0]
+            },
+            "optimizeCap": {
+                "unit": "bool",
+                "value": false
+            },
+            "outflow_direction": ["Electricity bus", "Heat bus"],
+            "simulation_annuity": {
+                "value": 60,
+                "unit": "currency/unit/simulation period"},
+            "type_oemof": "transformer"
+        },
+
         "test_asset_for_error_raising": {
             "efficiency": {
                 "unit": "factor",


### PR DESCRIPTION
Adresses #802, #532, #799, #599, #541, #372


**Changes proposed in this pull request**:
- [ ] Update data of `tests/benchmark_test_inputs/Feature_output_flows_as_list`
- [x] Update data of `tests/benchmark_test_inputs/Feature_output_flows_as_list`
- [~] Add pytest for multiple inputs and outputs for `C0.add_asset_to_asset_dict_for_each_flow_direction`
- [x] Add validity checks in C1 for multiple input- and output flows including tests
- [x] Implement multiple input or output flows for `D1.test_transformer_constant_efficiency_fix` including tests
- [ ] Implement multiple input or output flows for `D1.test_transformer_constant_efficiency_optimize` including tests
- [ ] Fix issue regarding dispatch price in `D1`
- [ ] Write benchmark test based on `tests/benchmark_test_inputs/Feature_input_flows_as_list`
- [ ] Write benchmark test based on `tests/benchmark_test_inputs/Feature_output_flows_as_list`
- [~] Update RTD explaining how multiple flows can be used 

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [ ] Update the CHANGELOG.md
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
