### PR TITLE
Feature/save lp file on server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Here is a template for new release sections
 - Tests `E3.test_add_total_consumption_from_provider_electricity_equivalent_two_providers_one_energy_carrier` and `E3.test_add_total_feedin_electricity_equivalent_two_providers_one_energy_carrier`(#932)
 - Add the argument `return_les` to the function `D0.run_oemof` to return the energy system if set to `True` (#923)
 - Save the content of the lp file into a string in the `dict_values` under `SIMULATION_SETTINGS->OUTPUT_LP_FILE` in server mode (#923)
-- Set `OUTPUT_LP_FILE` value to be always `True` when coming from EPA in server mode (#923)
+- Set `OUTPUT_LP_FILE` value to be by default `False` when coming from EPA in server mode (#923)
 
 ### Changed
 - `F0_output.parse_simulation_log`, so that `SIMULATION_RESULTS` are not overwritten anymore (#901)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Here is a template for new release sections
 - Benchmark test (`tests/benchmark_test_inputs/objective_value_exception_equal_annuity`) for in `F0_output.parse_simulation_log` and data stored to `SIMULATION_RESULTS` as well as `OBJECTIVE_VALUE` (#901)
 - Constants `BENCHMARK_TEST_INPUT_FOLDER` and `BENCHMARK_TEST_OUTPUT_FOLDER` in `tests/_constants.py` (#901)
 - Tests `E3.test_add_total_consumption_from_provider_electricity_equivalent_two_providers_one_energy_carrier` and `E3.test_add_total_feedin_electricity_equivalent_two_providers_one_energy_carrier`(#932)
+- Add the argument `return_les` to the function `D0.run_oemof` to return the energy system if set to `True` (#923)
+- Save the content of the lp file into a string in the `dict_values` under `SIMULATION_SETTINGS->OUTPUT_LP_FILE` in server mode (#923)
+- Set `OUTPUT_LP_FILE` value to be always `True` when coming from EPA in server mode (#923)
 
 ### Changed
 - `F0_output.parse_simulation_log`, so that `SIMULATION_RESULTS` are not overwritten anymore (#901)

--- a/src/multi_vector_simulator/D0_modelling_and_optimization.py
+++ b/src/multi_vector_simulator/D0_modelling_and_optimization.py
@@ -63,7 +63,7 @@ from multi_vector_simulator.utils.exceptions import (
 )
 
 
-def run_oemof(dict_values, save_energy_system_graph=False):
+def run_oemof(dict_values, save_energy_system_graph=False, return_les=False):
     """
     Creates and solves energy system model generated from excel template inputs.
     Each component is included by calling its constructor function in D1_model_components.
@@ -74,6 +74,12 @@ def run_oemof(dict_values, save_energy_system_graph=False):
         Includes all dictionary values describing the whole project, including costs,
         technical parameters and components. In C0_data_processing, each component was attributed
         with a certain in/output bus.
+
+    save_energy_system_graph: bool
+        if set to True, saves a local copy of the energy system's graph
+
+    return_les: bool
+        if set to True, the return also includes the local_energy_system in third position
 
     Returns
     -------
@@ -107,7 +113,10 @@ def run_oemof(dict_values, save_energy_system_graph=False):
 
     timer.stop(dict_values, start)
 
-    return results_meta, results_main
+    if return_les is True:
+        return results_meta, results_main, local_energy_system
+    else:
+        return results_meta, results_main
 
 
 class model_building:

--- a/src/multi_vector_simulator/server.py
+++ b/src/multi_vector_simulator/server.py
@@ -53,7 +53,10 @@ from multi_vector_simulator.utils import data_parser
 from multi_vector_simulator.utils.constants_json_strings import (
     SIMULATION_SETTINGS,
     OUTPUT_LP_FILE,
+    VALUE,
+    UNIT,
 )
+from multi_vector_simulator.utils.constants import TYPE_STR
 
 
 def run_simulation(json_dict, epa_format=True, **kwargs):
@@ -94,8 +97,6 @@ def run_simulation(json_dict, epa_format=True, **kwargs):
     else:
         screen_level = logging.INFO
 
-    lp_file_output = kwargs.get("lp_file_output", True)
-
     # Define logging settings and path for saving log
     logger.define_logging(screen_level=screen_level)
 
@@ -117,6 +118,11 @@ def run_simulation(json_dict, epa_format=True, **kwargs):
     logging.debug("Accessing script: B0_data_input_json")
     dict_values = B0.convert_from_json_to_special_types(json_dict)
 
+    # if True will return the lp file's content in dict_values
+    lp_file_output = dict_values[SIMULATION_SETTINGS][OUTPUT_LP_FILE][VALUE]
+    # to avoid the lp file being saved somewhere on the server
+    dict_values[SIMULATION_SETTINGS][OUTPUT_LP_FILE][VALUE] = False
+
     print("")
     logging.debug("Accessing script: C0_data_processing")
     C0.all(dict_values)
@@ -137,7 +143,8 @@ def run_simulation(json_dict, epa_format=True, **kwargs):
             with open(os.path.join(tmpdirname, "lp_file.lp")) as fp:
                 file_content = fp.read()
 
-        dict_values[SIMULATION_SETTINGS][OUTPUT_LP_FILE] = file_content
+        dict_values[SIMULATION_SETTINGS][OUTPUT_LP_FILE][VALUE] = file_content
+        dict_values[SIMULATION_SETTINGS][OUTPUT_LP_FILE][UNIT] = TYPE_STR
 
     print("")
     logging.debug("Accessing script: E0_evaluation")

--- a/src/multi_vector_simulator/utils/data_parser.py
+++ b/src/multi_vector_simulator/utils/data_parser.py
@@ -272,13 +272,14 @@ def convert_epa_params_to_mvs(epa_dict):
 
     - For `simulation_settings`:
         - parameter `TIMESTEP` is parsed as unit-value pair
-        - `OUTPUT_LP_FILE` always `True`
+        - `OUTPUT_LP_FILE` is set to `False` by default
     - For `project_data`: parameter `SCENARIO_DESCRIPTION` is defined as placeholder string.
     - `fix_cost` is not required, default value will be set if it is not provided.
     - For missing asset group `CONSTRAINTS` following parameters are added:
         - MINIMAL_RENEWABLE_FACTOR: 0
         - MAXIMUM_EMISSIONS: None
         - MINIMAL_DEGREE_OF_AUTONOMY: 0
+        - NET_ZERO_ENERGY: False
     - `ENERGY_STORAGE` assets:
         - Optimize cap written to main asset and removed from subassets
         - Units defined automatically (assumed: electricity system)
@@ -329,13 +330,19 @@ def convert_epa_params_to_mvs(epa_dict):
                         UNIT: "min",
                         VALUE: timestep,
                     }
+                # by default the lp file will not be outputted
+                output_lp_file = dict_values[param_group].get(OUTPUT_LP_FILE)
+                if output_lp_file is None:
+                    dict_values[param_group][OUTPUT_LP_FILE] = {
+                        UNIT: TYPE_BOOL,
+                        VALUE: False,
+                    }
+                else:
+                    dict_values[param_group][OUTPUT_LP_FILE] = {
+                        UNIT: TYPE_BOOL,
+                        VALUE: output_lp_file,
+                    }
 
-            # Always save the oemof lp file when running on the server
-            if param_group == SIMULATION_SETTINGS:
-                dict_values[param_group][OUTPUT_LP_FILE] = {
-                    UNIT: TYPE_BOOL,
-                    VALUE: True,
-                }
             if param_group == PROJECT_DATA:
                 if SCENARIO_DESCRIPTION not in dict_values[param_group]:
                     dict_values[param_group][

--- a/src/multi_vector_simulator/utils/data_parser.py
+++ b/src/multi_vector_simulator/utils/data_parser.py
@@ -340,7 +340,7 @@ def convert_epa_params_to_mvs(epa_dict):
                 else:
                     dict_values[param_group][OUTPUT_LP_FILE] = {
                         UNIT: TYPE_BOOL,
-                        VALUE: output_lp_file,
+                        VALUE: True if output_lp_file == "true" else False,
                     }
 
             if param_group == PROJECT_DATA:

--- a/src/multi_vector_simulator/utils/data_parser.py
+++ b/src/multi_vector_simulator/utils/data_parser.py
@@ -143,7 +143,7 @@ MAP_MVS_EPA = {value: key for (key, value) in MAP_EPA_MVS.items()}
 # Fields expected for parameters of json returned to EPA, all assets will be returned
 EPA_PARAM_KEYS = {
     PROJECT_DATA: [PROJECT_ID, PROJECT_NAME, SCENARIO_ID, SCENARIO_NAME],
-    SIMULATION_SETTINGS: [START_DATE, EVALUATED_PERIOD, TIMESTEP],
+    SIMULATION_SETTINGS: [START_DATE, EVALUATED_PERIOD, TIMESTEP, OUTPUT_LP_FILE],
     KPI: [KPI_SCALARS_DICT, KPI_UNCOUPLED_DICT, KPI_COST_MATRIX, KPI_SCALAR_MATRIX],
 }
 
@@ -272,7 +272,7 @@ def convert_epa_params_to_mvs(epa_dict):
 
     - For `simulation_settings`:
         - parameter `TIMESTEP` is parsed as unit-value pair
-        - `OUTPUT_LP_FILE` always `False`
+        - `OUTPUT_LP_FILE` always `True`
     - For `project_data`: parameter `SCENARIO_DESCRIPTION` is defined as placeholder string.
     - `fix_cost` is not required, default value will be set if it is not provided.
     - For missing asset group `CONSTRAINTS` following parameters are added:
@@ -330,13 +330,12 @@ def convert_epa_params_to_mvs(epa_dict):
                         VALUE: timestep,
                     }
 
-            # Never save the oemof lp file when running on the server
+            # Always save the oemof lp file when running on the server
             if param_group == SIMULATION_SETTINGS:
                 dict_values[param_group][OUTPUT_LP_FILE] = {
                     UNIT: TYPE_BOOL,
-                    VALUE: False,
+                    VALUE: True,
                 }
-
             if param_group == PROJECT_DATA:
                 if SCENARIO_DESCRIPTION not in dict_values[param_group]:
                     dict_values[param_group][
@@ -603,6 +602,11 @@ def convert_mvs_params_to_epa(mvs_dict, verbatim=False):
                         .set_index("label")
                         .to_json(orient="index")
                     )
+
+                # if the parameter is of type
+                if k == OUTPUT_LP_FILE:
+                    if epa_dict[param_group_epa][k][UNIT] == TYPE_BOOL:
+                        epa_dict[param_group_epa].pop(k)
 
     # manage which assets parameters are kept and which one are removed in epa_dict
     for asset_group in EPA_ASSET_KEYS:


### PR DESCRIPTION
Fix #907 

**Changes proposed in this pull request**:
- Add the argument `return_les` to the function `D0.run_oemof` to return the energy system if set to `True`
- Save the content of the lp file into a string under `SIMULATION_SETTINGS->OUTPUT_LP_FILE` in server mode

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] Update the CHANGELOG.md
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)



<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
