### PR TITLE
Freeze numpy version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Here is a template for new release sections
 - `F0_output.parse_simulation_log`, so that `SIMULATION_RESULTS` are not overwritten anymore (#901)
 - `input_template/csv_elements`: Added missing parameters and generalized units (#904)
 - `CONTRIBUTING.md` according to last lessons learnt (#904)
+-  Set numpy version to lower or equal than `1.19.4` (#924)
 
 ### Removed
 -

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -7,4 +7,4 @@ psutil
 kaleido>=0.0.2
 openpyxl>=3.0.5
 xlrd==1.2.0
-
+numpy<=1.19.4


### PR DESCRIPTION
Addresses temporarily #908 by treating symptoms but not the cause

**Changes proposed in this pull request**:
- Set numpy version to lower or equal than 1.19.4

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)



<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
