### PR TITLE
Return the optimized add capacity of storage assets to the epa

### DIFF
--- a/src/multi_vector_simulator/utils/data_parser.py
+++ b/src/multi_vector_simulator/utils/data_parser.py
@@ -208,6 +208,7 @@ EPA_ASSET_KEYS = {
         DISPATCH_PRICE,
         EFFICIENCY,
         "installed_capacity",
+        OPTIMIZED_ADD_CAP,
         LIFETIME,
         "maximum_capacity",
         "optimize_capacity",


### PR DESCRIPTION
- Let the optimized_add_cap be passed to epa results
- Get rid of the input_timeseries in the parameters returned to epa

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [ ] Update the CHANGELOG.md
- [ ] Apply black (`black . --exclude docs/`)
- [ ] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
