### PR TITLE
Bugfix: Multiple energy providers with one energy carrier not evaluated correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,16 @@ Here is a template for new release sections
 ### Added
 - Benchmark test (`tests/benchmark_test_inputs/objective_value_exception_equal_annuity`) for in `F0_output.parse_simulation_log` and data stored to `SIMULATION_RESULTS` as well as `OBJECTIVE_VALUE` (#901)
 - Constants `BENCHMARK_TEST_INPUT_FOLDER` and `BENCHMARK_TEST_OUTPUT_FOLDER` in `tests/_constants.py` (#901)
+- Tests `E3.test_add_total_consumption_from_provider_electricity_equivalent_two_providers_one_energy_carrier` and `E3.test_add_total_feedin_electricity_equivalent_two_providers_one_energy_carrier`(#932)
 
 ### Changed
 - `F0_output.parse_simulation_log`, so that `SIMULATION_RESULTS` are not overwritten anymore (#901)
 - `input_template/csv_elements`: Added missing parameters and generalized units (#904)
 - `CONTRIBUTING.md` according to last lessons learnt (#904)
--  Set numpy version to lower or equal than `1.19.4` (#924)
+- Set numpy version to lower or equal than `1.19.4` (#924)
+- `F2.create_app()` to specify tab name of Dash report to `scenario_name` (`scenario_id`) instead of `Dash` (#934)
+- Bugfix in functions `test_add_total_consumption_from_provider_electricity_equivalent` and `E3.test_add_total_feedin_electricity_equivalent` (#932)
+- `version.py`: Version number increased to 1.0.2dev, so simulations run before and after this fix can easily be identified (in the autoreport) (#932)
 
 ### Removed
 -
@@ -37,6 +41,8 @@ Here is a template for new release sections
 ### Fixed
 - `OBJECTIVE_VALUE`, `SIMULTATION_TIME`, `MODELLING_TIME` now included in the `json_with_results.json` (#901)
 - Missing parameters in `input_template/csv_elements` (#904)
+- Confusing Dash report tab names (#933)
+- Calculation of `total_feedin` and `total_consumption_from_providers`, where multiple providers of one energy carrier were not aggregated correctly (#931)
 
 ## [1.0.0] - 2021-05-31
 

--- a/src/multi_vector_simulator/E3_indicator_calculation.py
+++ b/src/multi_vector_simulator/E3_indicator_calculation.py
@@ -779,6 +779,7 @@ def add_total_feedin_electricity_equivalent(dict_values):
 
     Tested with
     - test_add_total_feedin_electricity_equivalent()
+    - test_add_total_feedin_electricity_equivalent_two_providers_one_energy_carrier
     """
 
     total_feedin_dict = {}
@@ -823,6 +824,7 @@ def add_total_consumption_from_provider_electricity_equivalent(dict_values):
     -----
     Tested with:
     - E3.test_add_total_consumption_from_provider_electricity_equivalent()
+    - E3.test_add_total_consumption_from_provider_electricity_equivalent_two_providers_one_energy_carrier
     """
 
     total_consumption_dict = {}

--- a/src/multi_vector_simulator/E3_indicator_calculation.py
+++ b/src/multi_vector_simulator/E3_indicator_calculation.py
@@ -788,14 +788,12 @@ def add_total_feedin_electricity_equivalent(dict_values):
         # load total flow into the dso sink
         feedin_sink = str(dso + DSO_FEEDIN)
         energy_carrier = dict_values[ENERGY_CONSUMPTION][feedin_sink][ENERGY_VECTOR]
-        total_feedin_dict.update({energy_carrier: {}})
-        total_feedin_dict.update(
-            {
-                energy_carrier: dict_values[ENERGY_CONSUMPTION][feedin_sink][
-                    TOTAL_FLOW
-                ][VALUE]
-            }
-        )
+        if energy_carrier not in total_feedin_dict:
+            total_feedin_dict.update({energy_carrier: 0})
+
+        total_feedin_dict[energy_carrier] += dict_values[ENERGY_CONSUMPTION][
+            feedin_sink
+        ][TOTAL_FLOW][VALUE]
 
     # Append total feedin in electricity equivalent to kpi
     calculate_electricity_equivalent_for_a_set_of_aggregated_values(
@@ -835,14 +833,12 @@ def add_total_consumption_from_provider_electricity_equivalent(dict_values):
         energy_carrier = dict_values[ENERGY_PRODUCTION][consumption_source][
             ENERGY_VECTOR
         ]
-        total_consumption_dict.update({energy_carrier: {}})
-        total_consumption_dict.update(
-            {
-                energy_carrier: dict_values[ENERGY_PRODUCTION][consumption_source][
-                    TOTAL_FLOW
-                ][VALUE]
-            }
-        )
+        if energy_carrier not in total_consumption_dict:
+            total_consumption_dict.update({energy_carrier: 0})
+
+        total_consumption_dict[energy_carrier] += dict_values[ENERGY_PRODUCTION][
+            consumption_source
+        ][TOTAL_FLOW][VALUE]
 
     # Append total feedin in electricity equivalent to kpi
     calculate_electricity_equivalent_for_a_set_of_aggregated_values(

--- a/src/multi_vector_simulator/version.py
+++ b/src/multi_vector_simulator/version.py
@@ -1,4 +1,4 @@
 # versioning scheme: Major release.Minor release.Patches
-version_num = "1.0.1dev"
+version_num = "1.0.2dev"
 # date format iso8601: YYYY-MM-DD
-version_date = "2021-05-31"
+version_date = "2022-03-11"

--- a/tests/test_E3_indicator_calculation.py
+++ b/tests/test_E3_indicator_calculation.py
@@ -580,6 +580,38 @@ def test_add_total_feedin_electricity_equivalent():
     ), f"The total_feedin_electricity_equivalent is added successfully to the list of KPI's."
 
 
+def test_add_total_feedin_electricity_equivalent_two_providers_one_energy_carrier():
+    """ """
+
+    dso = ["DSO-1", "DSO-2"]
+    feedin = 1000
+    consumption_asset = [str(dso[0] + DSO_FEEDIN), str(dso[1] + DSO_FEEDIN)]
+    dict_values_feedin = {
+        ENERGY_PROVIDERS: {dso[0], dso[1]},
+        ENERGY_CONSUMPTION: {
+            consumption_asset[0]: {
+                ENERGY_VECTOR: "Electricity",
+                TOTAL_FLOW: {VALUE: feedin},
+            },
+            consumption_asset[1]: {
+                ENERGY_VECTOR: "Electricity",
+                TOTAL_FLOW: {VALUE: feedin},
+            },
+        },
+        KPI: {KPI_SCALARS_DICT: {}},
+        PROJECT_DATA: {LES_ENERGY_VECTOR_S: {electricity: electricity}},
+    }
+
+    E3.add_total_feedin_electricity_equivalent(dict_values_feedin)
+
+    assert (
+        dict_values_feedin[KPI][KPI_SCALARS_DICT][
+            TOTAL_FEEDIN + SUFFIX_ELECTRICITY_EQUIVALENT
+        ]
+        == 2 * feedin
+    ), f"Multiple energy providers are not correctly evaluated, the total feedin is not the aggregated flow of each energy provider, which would be {2*feedin}, but {dict_values_feedin[KPI][KPI_SCALARS_DICT][TOTAL_FEEDIN + SUFFIX_ELECTRICITY_EQUIVALENT]}."
+
+
 def test_add_onsite_energy_fraction():
     """ """
 
@@ -860,3 +892,37 @@ def test_add_total_consumption_from_provider_electricity_equivalent():
         assert (
             dict_values[KPI][KPI_SCALARS_DICT][kpi] == exp
         ), f"The {kpi} should have been {exp} but is {dict_values[KPI][KPI_SCALARS_DICT][kpi]}."
+
+
+def test_add_total_consumption_from_provider_electricity_equivalent_two_providers_one_energy_carrier():
+    dso = ["DSO-1", "DSO-2"]
+    exp = 100
+    consumption_source = [str(dso[0] + DSO_CONSUMPTION), str(dso[1] + DSO_CONSUMPTION)]
+
+    dict_values = {
+        KPI: {KPI_SCALARS_DICT: {}},
+        ENERGY_PROVIDERS: {
+            dso[0]: {ENERGY_VECTOR: electricity},
+            dso[1]: {ENERGY_VECTOR: electricity},
+        },
+        ENERGY_PRODUCTION: {
+            consumption_source[0]: {
+                TOTAL_FLOW: {VALUE: exp},
+                ENERGY_VECTOR: electricity,
+            },
+            consumption_source[1]: {
+                TOTAL_FLOW: {VALUE: exp},
+                ENERGY_VECTOR: electricity,
+            },
+        },
+    }
+
+    E3.add_total_consumption_from_provider_electricity_equivalent(dict_values)
+    for kpi in [
+        TOTAL_CONSUMPTION_FROM_PROVIDERS + electricity,
+        TOTAL_CONSUMPTION_FROM_PROVIDERS + electricity + SUFFIX_ELECTRICITY_EQUIVALENT,
+        TOTAL_CONSUMPTION_FROM_PROVIDERS + SUFFIX_ELECTRICITY_EQUIVALENT,
+    ]:
+        assert (
+            dict_values[KPI][KPI_SCALARS_DICT][kpi] == 2 * exp
+        ), f"Multiple energy providers are not correctly evaluated, the  {kpi}  is not the aggregated flow of each energy provider, which would be {2*exp}, but is {dict_values[KPI][KPI_SCALARS_DICT][kpi]}."


### PR DESCRIPTION
Fix #931 

**Changes proposed in this pull request**:
- Add pytests to check if multiple energy providers with one energy carrier are evaluated correctly
- Fix `E3.add_total_consumption_from_provider_electricity_equivalent` and  `E3.add_total_feedin_electricity_equivalent`
- Update version number to `1.0.2dev` so that it is possible to clearly identify the simulations run before and after this fix (in the autoreport)

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [x] For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)