### PR TITLE
Set Dash report tab name as: `scenario_name` (`scenario_id`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ Here is a template for new release sections
 - `F0_output.parse_simulation_log`, so that `SIMULATION_RESULTS` are not overwritten anymore (#901)
 - `input_template/csv_elements`: Added missing parameters and generalized units (#904)
 - `CONTRIBUTING.md` according to last lessons learnt (#904)
--  Set numpy version to lower or equal than `1.19.4` (#924)
+- Set numpy version to lower or equal than `1.19.4` (#924)
+- `F2.create_app()` to specify tab name of Dash report to `scenario_name` (`scenario_id`) instead of `Dash` (#934)
 
 ### Removed
 -
@@ -37,7 +38,8 @@ Here is a template for new release sections
 ### Fixed
 - `OBJECTIVE_VALUE`, `SIMULTATION_TIME`, `MODELLING_TIME` now included in the `json_with_results.json` (#901)
 - Missing parameters in `input_template/csv_elements` (#904)
-
+- Confusing Dash report tab names (#933)
+- 
 ## [1.0.0] - 2021-05-31
 
 ### Added

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -171,7 +171,6 @@ def open_in_browser(app, timeout=600):
     -------
     Nothing, but the web app version of the auto-report is displayed in a browser.
     """
-
     td = threading.Thread(target=app.run_server)
     td.daemon = True
     td.start()
@@ -654,8 +653,11 @@ def create_app(results_json, path_sim_output=None):
         },
     ]
 
+    tab_name = f"{results_json[PROJECT_DATA][SCENARIO_NAME]} ({results_json[PROJECT_DATA][SCENARIO_ID]})"
     app = dash.Dash(
-        assets_folder=asset_folder, external_stylesheets=external_stylesheets,
+        assets_folder=asset_folder,
+        external_stylesheets=external_stylesheets,
+        title=tab_name,
     )
 
     # Reading the relevant user-inputs from the JSON_WITH_RESULTS.json file into Pandas dataframes


### PR DESCRIPTION
Fix #933 

**Changes proposed in this pull request**:
- Specify tab name of Dash report to `scenario_name` (`scenario_id`) instead of `Dash`

![grafik](https://user-images.githubusercontent.com/44204527/157853057-b0bde9b1-1e0c-4ce1-b65d-6ec04a0869bd.png)

The following steps were realized, as well (if applies):
- [X] Use in-line comments to explain your code
- [X] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [X] For new functionalities: Explain in readthedocs
- [X] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [X] Update the CHANGELOG.md
- [X] Apply black (`black . --exclude docs/`)
- [X] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)
