### PR TITLE
Add sankey diagram to output and report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Here is a template for new release sections
 - Function `server.run_sensitivity_analysis_step` to perform one step of a sensitivity analysis (#936)
 - Function `utils.nested_dict_crawler` to return mapping of path within a nested dict to the keys at the lowest nested level (#936)
 - Test `test_utils.TestAccessKPIs` to test the nested dict utils functions (#936)
+- `sankey` method to the `ESGraphRenderer` class to return a sankey diagram (#935)
+- `plot_sankey_diagramm` function in `D0_modelling_and_optimization.py` to add the dict of the sankey diagram (#935)
+- `ready_sankey_diagram` in `F2_autoreport.py` to add sankey diagram to output and report (#935)
 
 ### Changed
 - `F0_output.parse_simulation_log`, so that `SIMULATION_RESULTS` are not overwritten anymore (#901)
@@ -42,6 +45,7 @@ Here is a template for new release sections
 - `version.py`: Version number increased to 1.0.2dev, so simulations run before and after this fix can easily be identified (in the autoreport) (#932)
 - Enable capacity optimization for storage assets in the epa (#936)
 - Make the `utils` function `get_nested_value`and `set_nested_value` raise a Key error with a traceback indicating where in the nested dict this key was missing to help debugging (#936)
+- When the user ask for images to be produced (`-pdf` or `-png` options) a sankey diagram is added to the report and to the `dict_values` under `[PATH_TO_PLOTS][PLOT_SANKEY]` (#935)
 
 ### Removed
 - Input timeseries is now not returned to epa in `utils.data_parser.py` (#936)

--- a/src/multi_vector_simulator/D0_modelling_and_optimization.py
+++ b/src/multi_vector_simulator/D0_modelling_and_optimization.py
@@ -23,7 +23,7 @@ import os
 import timeit
 import warnings
 
-from oemof.solph import processing
+from oemof.solph import processing, network
 import oemof.solph as solph
 
 import multi_vector_simulator.D1_model_components as D1
@@ -33,6 +33,7 @@ from multi_vector_simulator.utils.constants import (
     PATH_OUTPUT_FOLDER,
     ES_GRAPH,
     PATHS_TO_PLOTS,
+    PLOT_SANKEY,
     PLOTS_ES,
     LP_FILE,
 )
@@ -109,6 +110,10 @@ def run_oemof(dict_values, save_energy_system_graph=False, return_les=False):
 
     model, results_main, results_meta = model_building.simulating(
         dict_values, model, local_energy_system
+    )
+
+    model_building.plot_sankey_diagramm(
+        dict_values, model, save_energy_system_graph=save_energy_system_graph
     )
 
     timer.stop(dict_values, start)
@@ -246,6 +251,34 @@ class model_building:
             logging.debug("Created graph of the energy system model.")
 
             graph.render()
+
+    def plot_sankey_diagramm(dict_values, model, save_energy_system_graph=False):
+        """
+        Prepare a sankey diagram of the simulated energy model
+
+        Parameters
+        ----------
+        dict_values: dict
+            All simulation inputs
+
+         model: `oemof.solph.network.EnergySystem`
+            oemof-solph object for energy system model
+
+        save_energy_system_graph: bool
+            if True, save the graph in the mvs output folder
+            Default: False
+
+        Returns
+        -------
+
+        """
+        if save_energy_system_graph is True:
+            from multi_vector_simulator.F1_plotting import ESGraphRenderer
+
+            graph = ESGraphRenderer(model)
+            dict_values[PATHS_TO_PLOTS][PLOT_SANKEY] = graph.sankey(
+                model.results["main"]
+            )
 
     def store_lp_file(dict_values, local_energy_system):
         """

--- a/src/multi_vector_simulator/F2_autoreport.py
+++ b/src/multi_vector_simulator/F2_autoreport.py
@@ -44,6 +44,7 @@ from multi_vector_simulator.utils.constants import (
     REPO_PATH,
     PATH_OUTPUT_FOLDER,
     PATHS_TO_PLOTS,
+    PLOT_SANKEY,
     OUTPUT_FOLDER,
     INPUTS_COPY,
     CSV_ELEMENTS,
@@ -89,6 +90,7 @@ from multi_vector_simulator.F1_plotting import (
     plot_piecharts_of_costs,
     plot_optimized_capacities,
     plot_instant_power,
+    plot_sankey,
 )
 
 from multi_vector_simulator.version import version_num, version_date
@@ -526,6 +528,40 @@ def ready_costs_pie_plots(dict_values, only_print=False):
         for comp_id, fig in figs.items()
     ]
     return pie_plots
+
+
+def ready_sankey_diagram(dict_values, only_print=False):
+    fig = plot_sankey(dict_values)
+    # Specific modifications for print-only version
+    # fig2 = copy.deepcopy(fig)
+    # Make the legend horizontally oriented so as to prevent the legend from being cut off
+    # fig2.update_layout(legend=dict(orientation="h", y=-0.3, x=0.5, xanchor="center"))
+
+    # Static image for the pdf report
+    rendered_plots = [
+        html.Img(
+            className="print-only dash-plot",
+            src="data:image/png;base64,{}".format(
+                base64.b64encode(
+                    fig.to_image(format="png", height=500, width=900)
+                ).decode(),
+            ),
+        )
+    ]
+
+    # Dynamic plotly figure for the app
+    if only_print is False:
+        rendered_plots.append(
+            dcc.Graph(
+                className="no-print",
+                id="sankey-diagram",
+                figure=fig,
+                responsive=True,
+                style={"width": "100%", "height": "900px"},
+            )
+        )
+
+    return rendered_plots
 
 
 def encode_image_file(img_path):
@@ -988,6 +1024,12 @@ def create_app(results_json, path_sim_output=None):
                             ),
                             make_dash_data_table(df_kpi_sectors),
                         ],
+                    ),
+                    insert_subsection(
+                        title="Sankey diagram",
+                        content=ready_sankey_diagram(
+                            dict_values=results_json, only_print=False,
+                        ),
                     ),
                     insert_subsection(
                         title="Economic Evaluation",

--- a/src/multi_vector_simulator/utils/constants.py
+++ b/src/multi_vector_simulator/utils/constants.py
@@ -329,6 +329,7 @@ PLOTS_ES = "graphviz"
 PLOTS_PERFORMANCE = "performance"
 PLOTS_COSTS = "costs"
 PLOTS_BUSSES = "flows_on_busses"
+PLOT_SANKEY = "sankey"
 
 # structure of the dict containing generated plots filenames in results_json file
 DICT_PLOTS = {


### PR DESCRIPTION
**Changes proposed in this pull request**:
- When the user ask for images to be produced (`-pdf` or `-png` options) a sankey diagram is added to the report and to the `dict_values` under `[PATH_TO_PLOTS][PLOT_SANKEY]`
- `plot_sankey_diagramm` function in `D0_modelling_and_optimization.py` to add the dict of the sankey diagram
- `ready_sankey_diagram` in `F2_autoreport.py` to add sankey diagram to output and report

#930 should be merged first and this be rebased onto then


The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
