### PR TITLE
Allow feedin capping for DSO

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -383,5 +383,5 @@ html_static_path = ["_static"]
 # These paths are either relative to html_static_path
 # or fully qualified paths (eg. https://...)
 html_css_files = [
-    'table-style.css',
+    "table-style.css",
 ]

--- a/src/multi_vector_simulator/C0_data_processing.py
+++ b/src/multi_vector_simulator/C0_data_processing.py
@@ -1043,9 +1043,7 @@ def define_transformer_for_peak_demand_pricing(
         # LIFETIME: {VALUE: 100, UNIT: UNIT_YEAR},
     }
     if dict_dso.get(DSO_FEEDIN_CAP, None) is not None:
-        dso_feedin_transformer[MAXIMUM_CAP] = (
-            {VALUE: dict_dso[DSO_FEEDIN_CAP][VALUE], UNIT: dict_dso[UNIT]},
-        )
+        dso_feedin_transformer[MAXIMUM_CAP] = {VALUE: dict_dso[DSO_FEEDIN_CAP][VALUE], UNIT: dict_dso[UNIT]}
 
         logging.info(
             f"Capping {dict_dso[LABEL]} feedin with maximum capacity {dict_dso[DSO_FEEDIN_CAP][VALUE]}"

--- a/src/multi_vector_simulator/C0_data_processing.py
+++ b/src/multi_vector_simulator/C0_data_processing.py
@@ -1043,7 +1043,10 @@ def define_transformer_for_peak_demand_pricing(
         # LIFETIME: {VALUE: 100, UNIT: UNIT_YEAR},
     }
     if dict_dso.get(DSO_FEEDIN_CAP, None) is not None:
-        dso_feedin_transformer[MAXIMUM_CAP] = {VALUE: dict_dso[DSO_FEEDIN_CAP][VALUE], UNIT: dict_dso[UNIT]}
+        dso_feedin_transformer[MAXIMUM_CAP] = {
+            VALUE: dict_dso[DSO_FEEDIN_CAP][VALUE],
+            UNIT: dict_dso[UNIT],
+        }
 
         logging.info(
             f"Capping {dict_dso[LABEL]} feedin with maximum capacity {dict_dso[DSO_FEEDIN_CAP][VALUE]}"

--- a/src/multi_vector_simulator/C0_data_processing.py
+++ b/src/multi_vector_simulator/C0_data_processing.py
@@ -42,6 +42,9 @@ from multi_vector_simulator.utils.constants import (
 from multi_vector_simulator.utils.exceptions import MaximumCapValueInvalid
 
 from multi_vector_simulator.utils.constants_json_strings import *
+from multi_vector_simulator.utils.helpers import (
+    feedin_cap_bus_name,
+)
 from multi_vector_simulator.utils.exceptions import InvalidPeakDemandPricingPeriodsError
 import multi_vector_simulator.B0_data_input_json as B0
 import multi_vector_simulator.C1_verification as C1
@@ -732,12 +735,18 @@ def define_auxiliary_assets_of_energy_providers(dict_values, dso_name):
     )
     dict_feedin = change_sign_of_feedin_tariff(dso_dict[FEEDIN_TARIFF], dso_name)
 
+    # insert a transformer and a bus between existing bus and dso feedin in order to cap the maximal amount of feedin
+    if dso_dict.get(DSO_FEEDIN_CAP, None) is not None:
+        inflow_bus_name = feedin_cap_bus_name(dso_dict[INFLOW_DIRECTION])
+    else:
+        inflow_bus_name = dso_dict[INFLOW_DIRECTION]
+
     # define feed-in sink of the DSO
     define_sink(
         dict_values=dict_values,
         asset_key=dso_name + DSO_FEEDIN,
         price=dict_feedin,
-        inflow_direction=dict_values[ENERGY_PROVIDERS][dso][INFLOW_DIRECTION],
+        inflow_direction=inflow_bus_name,
         specific_costs={VALUE: 0, UNIT: CURR + "/" + UNIT},
         energy_vector=dso_dict[ENERGY_VECTOR],
     )

--- a/src/multi_vector_simulator/C0_data_processing.py
+++ b/src/multi_vector_simulator/C0_data_processing.py
@@ -44,6 +44,7 @@ from multi_vector_simulator.utils.exceptions import MaximumCapValueInvalid
 from multi_vector_simulator.utils.constants_json_strings import *
 from multi_vector_simulator.utils.helpers import (
     feedin_cap_bus_name,
+    peak_demand_bus_name,
 )
 from multi_vector_simulator.utils.exceptions import InvalidPeakDemandPricingPeriodsError
 import multi_vector_simulator.B0_data_input_json as B0
@@ -1004,7 +1005,7 @@ def define_transformer_for_peak_demand_pricing(
         LABEL: transformer_name,
         OPTIMIZE_CAP: {VALUE: True, UNIT: TYPE_BOOL},
         INSTALLED_CAP: {VALUE: 0, UNIT: dict_dso[UNIT]},
-        INFLOW_DIRECTION: dict_dso[INFLOW_DIRECTION] + DSO_PEAK_DEMAND_SUFFIX,
+        INFLOW_DIRECTION: peak_demand_bus_name(dict_dso[INFLOW_DIRECTION]),
         OUTFLOW_DIRECTION: dict_dso[OUTFLOW_DIRECTION],
         AVAILABILITY_DISPATCH: timeseries_availability,
         EFFICIENCY: {VALUE: 1, UNIT: "factor"},

--- a/src/multi_vector_simulator/C1_verification.py
+++ b/src/multi_vector_simulator/C1_verification.py
@@ -778,8 +778,10 @@ def check_for_sufficient_assets_on_busses(dict_values):
     - test_C1_verification.test_check_for_sufficient_assets_on_busses_skipped_for_peak_demand_pricing_bus()
     """
     for bus in dict_values[ENERGY_BUSSES]:
-        if len(dict_values[ENERGY_BUSSES][bus][ASSET_DICT]) < 3 and (
-            DSO_PEAK_DEMAND_SUFFIX not in bus or DSO_FEEDIN_CAP not in bus
+        if (
+            len(dict_values[ENERGY_BUSSES][bus][ASSET_DICT]) < 3
+            and DSO_PEAK_DEMAND_SUFFIX not in bus
+            and DSO_FEEDIN_CAP not in bus
         ):
             asset_string = ", ".join(
                 map(str, dict_values[ENERGY_BUSSES][bus][ASSET_DICT].keys())

--- a/src/multi_vector_simulator/C1_verification.py
+++ b/src/multi_vector_simulator/C1_verification.py
@@ -30,7 +30,6 @@ from multi_vector_simulator.utils.constants import (
     DISPLAY_OUTPUT,
     OVERWRITE,
     DEFAULT_WEIGHTS_ENERGY_CARRIERS,
-    DSO_PEAK_DEMAND_SUFFIX,
 )
 from multi_vector_simulator.utils.constants_json_strings import (
     PROJECT_DURATION,
@@ -86,6 +85,7 @@ from multi_vector_simulator.utils.constants_json_strings import (
     MAXIMUM_EMISSIONS,
     CONSTRAINTS,
     RENEWABLE_SHARE_DSO,
+    DSO_PEAK_DEMAND_SUFFIX,
     DSO_FEEDIN_CAP,
 )
 

--- a/src/multi_vector_simulator/C1_verification.py
+++ b/src/multi_vector_simulator/C1_verification.py
@@ -86,6 +86,7 @@ from multi_vector_simulator.utils.constants_json_strings import (
     MAXIMUM_EMISSIONS,
     CONSTRAINTS,
     RENEWABLE_SHARE_DSO,
+    DSO_FEEDIN_CAP,
 )
 
 # Necessary for check_for_label_duplicates()
@@ -777,9 +778,8 @@ def check_for_sufficient_assets_on_busses(dict_values):
     - test_C1_verification.test_check_for_sufficient_assets_on_busses_skipped_for_peak_demand_pricing_bus()
     """
     for bus in dict_values[ENERGY_BUSSES]:
-        if (
-            len(dict_values[ENERGY_BUSSES][bus][ASSET_DICT]) < 3
-            and DSO_PEAK_DEMAND_SUFFIX not in bus
+        if len(dict_values[ENERGY_BUSSES][bus][ASSET_DICT]) < 3 and (
+            DSO_PEAK_DEMAND_SUFFIX not in bus or DSO_FEEDIN_CAP not in bus
         ):
             asset_string = ", ".join(
                 map(str, dict_values[ENERGY_BUSSES][bus][ASSET_DICT].keys())

--- a/src/multi_vector_simulator/C1_verification.py
+++ b/src/multi_vector_simulator/C1_verification.py
@@ -229,7 +229,10 @@ def check_feedin_tariff_vs_levelized_cost_of_generation_of_production(dict_value
                         if optimze_cap == True and maximum_cap is None:
 
                             msg = f"Feed-in tariff of {energy_vector} ({round(feedin_tariff[VALUE],4)}) > {log_message_object} with {round(levelized_cost_of_generation,4)}. {warning_message_hint_unbound}"
-                            if DSO_FEEDIN_CAP in dict_values[ENERGY_PROVIDERS][provider]:
+                            if (
+                                DSO_FEEDIN_CAP
+                                in dict_values[ENERGY_PROVIDERS][provider]
+                            ):
                                 logging.warning(msg)
                             else:
                                 raise ValueError(msg)
@@ -254,7 +257,10 @@ def check_feedin_tariff_vs_levelized_cost_of_generation_of_production(dict_value
                         if optimze_cap == True and maximum_cap is None:
                             instances = sum(boolean)  # Count instances
                             msg = f"Feed-in tariff of {energy_vector} > {log_message_object} in {instances} during the simulation time. {warning_message_hint_unbound}"
-                            if DSO_FEEDIN_CAP in dict_values[ENERGY_PROVIDERS][provider]:
+                            if (
+                                DSO_FEEDIN_CAP
+                                in dict_values[ENERGY_PROVIDERS][provider]
+                            ):
                                 logging.warning(msg)
                             else:
                                 raise ValueError(msg)

--- a/src/multi_vector_simulator/C1_verification.py
+++ b/src/multi_vector_simulator/C1_verification.py
@@ -227,8 +227,12 @@ def check_feedin_tariff_vs_levelized_cost_of_generation_of_production(dict_value
                     if diff > 0:
                         # This can result in an unbound solution if optimizeCap is True and maximumCap is None
                         if optimze_cap == True and maximum_cap is None:
+
                             msg = f"Feed-in tariff of {energy_vector} ({round(feedin_tariff[VALUE],4)}) > {log_message_object} with {round(levelized_cost_of_generation,4)}. {warning_message_hint_unbound}"
-                            raise ValueError(msg)
+                            if DSO_FEEDIN_CAP in dict_values[ENERGY_PROVIDERS][provider]:
+                                logging.warning(msg)
+                            else:
+                                raise ValueError(msg)
                         # If maximumCap is not None the maximum capacity of the production asset will be installed
                         elif optimze_cap == True and maximum_cap is not None:
                             msg = f"Feed-in tariff of {energy_vector} ({round(feedin_tariff[VALUE],4)}) > {log_message_object} with {round(levelized_cost_of_generation,4)}. {warning_message_hint_maxcap}"
@@ -250,7 +254,10 @@ def check_feedin_tariff_vs_levelized_cost_of_generation_of_production(dict_value
                         if optimze_cap == True and maximum_cap is None:
                             instances = sum(boolean)  # Count instances
                             msg = f"Feed-in tariff of {energy_vector} > {log_message_object} in {instances} during the simulation time. {warning_message_hint_unbound}"
-                            raise ValueError(msg)
+                            if DSO_FEEDIN_CAP in dict_values[ENERGY_PROVIDERS][provider]:
+                                logging.warning(msg)
+                            else:
+                                raise ValueError(msg)
                         # If maximumCap is not None the maximum capacity of the production asset will be installed
                         elif optimze_cap == True and maximum_cap is not None:
                             msg = f"Feed-in tariff of {energy_vector} > {log_message_object} in {instances} during the simulation time. {warning_message_hint_maxcap}"
@@ -292,8 +299,12 @@ def check_feedin_tariff_vs_energy_price(dict_values):
         diff = feedin_tariff[VALUE] - electricity_price[VALUE]
         if isinstance(diff, float) or isinstance(diff, int):
             if diff > 0:
+
                 msg = f"Feed-in tariff > energy price for the energy provider asset '{dict_values[ENERGY_PROVIDERS][provider][LABEL]}' would cause an unbound solution and terminate the optimization. Please reconsider your feed-in tariff and energy price."
-                raise ValueError(msg)
+                if DSO_FEEDIN_CAP in dict_values[ENERGY_PROVIDERS][provider]:
+                    logging.warning(msg)
+                else:
+                    raise ValueError(msg)
             else:
                 logging.debug(
                     f"Feed-in tariff < energy price for energy provider asset '{dict_values[ENERGY_PROVIDERS][provider][LABEL]}'"
@@ -304,8 +315,11 @@ def check_feedin_tariff_vs_energy_price(dict_values):
             ]  # True if there is an instance where feed-in tariff > electricity_price
             if any(boolean) is True:
                 instances = sum(boolean)  # Count instances
-                msg = f"Feed-in tariff > energy price in {instances} during the simulation time for the energy provider asset '{dict_values[ENERGY_PROVIDERS][provider][LABEL]}'. This would cause an unbound solution and terminate the optimization. Please reconsider your feed-in tariff and energy price."
-                raise ValueError(msg)
+                msg = f"Feed-in tariff > energy price during {instances} timesteps of the simulation for the energy provider asset '{dict_values[ENERGY_PROVIDERS][provider][LABEL]}'. This would cause an unbound solution and terminate the optimization. Please reconsider your feed-in tariff and energy price."
+                if DSO_FEEDIN_CAP in dict_values[ENERGY_PROVIDERS][provider]:
+                    logging.warning(msg)
+                else:
+                    raise ValueError(msg)
             else:
                 logging.debug(
                     f"Feed-in tariff < energy price for energy provider asset '{dict_values[ENERGY_PROVIDERS][provider][LABEL]}'"

--- a/src/multi_vector_simulator/E3_indicator_calculation.py
+++ b/src/multi_vector_simulator/E3_indicator_calculation.py
@@ -1014,9 +1014,12 @@ def equation_onsite_energy_matching(
     """
     if total_demand == 0:
         total_demand = total_feedin
-    onsite_energy_matching = (
-        total_generation - total_feedin - total_excess
-    ) / total_demand
+    if total_demand != 0:
+        onsite_energy_matching = (
+            total_generation - total_feedin - total_excess
+        ) / total_demand
+    else:
+        onsite_energy_matching = 0
     return onsite_energy_matching
 
 

--- a/src/multi_vector_simulator/E3_indicator_calculation.py
+++ b/src/multi_vector_simulator/E3_indicator_calculation.py
@@ -580,9 +580,12 @@ def equation_degree_of_autonomy(total_consumption_from_energy_provider, total_de
     Tested with
     - test_equation_degree_of_autonomy()
     """
-    degree_of_autonomy = (
-        total_demand - total_consumption_from_energy_provider
-    ) / total_demand
+    if total_demand == 0:
+        degree_of_autonomy = 0
+    else:
+        degree_of_autonomy = (
+            total_demand - total_consumption_from_energy_provider
+        ) / total_demand
 
     return degree_of_autonomy
 
@@ -676,7 +679,10 @@ def equation_degree_of_net_zero_energy(
     - test_equation_degree_of_net_zero_energy_greater_one()
 
     """
-    degree_of_nze = 1 + (total_feedin - total_grid_consumption) / total_demand
+    if total_demand == 0:
+        degree_of_nze = 1
+    else:
+        degree_of_nze = 1 + (total_feedin - total_grid_consumption) / total_demand
 
     return degree_of_nze
 
@@ -1006,6 +1012,8 @@ def equation_onsite_energy_matching(
     Tested with
     - test_equation_onsite_energy_matching()
     """
+    if total_demand == 0:
+        total_demand = total_feedin
     onsite_energy_matching = (
         total_generation - total_feedin - total_excess
     ) / total_demand
@@ -1092,12 +1100,16 @@ def add_specific_emissions_per_electricity_equivalent(dict_values):
 
     """
     # emissions per kWheleq
-    emissions_kWheleq = (
-        dict_values[KPI][KPI_SCALARS_DICT][TOTAL_EMISSIONS]
-        / dict_values[KPI][KPI_SCALARS_DICT][
+    total_demand = dict_values[KPI][KPI_SCALARS_DICT][
             TOTAL_DEMAND + SUFFIX_ELECTRICITY_EQUIVALENT
         ]
-    )
+    if total_demand == 0:
+        emissions_kWheleq = 0
+    else:
+        emissions_kWheleq = (
+            dict_values[KPI][KPI_SCALARS_DICT][TOTAL_EMISSIONS]
+            / total_demand
+        )
     dict_values[KPI][KPI_SCALARS_DICT].update(
         {SPECIFIC_EMISSIONS_ELEQ: emissions_kWheleq}
     )

--- a/src/multi_vector_simulator/E3_indicator_calculation.py
+++ b/src/multi_vector_simulator/E3_indicator_calculation.py
@@ -1104,14 +1104,13 @@ def add_specific_emissions_per_electricity_equivalent(dict_values):
     """
     # emissions per kWheleq
     total_demand = dict_values[KPI][KPI_SCALARS_DICT][
-            TOTAL_DEMAND + SUFFIX_ELECTRICITY_EQUIVALENT
-        ]
+        TOTAL_DEMAND + SUFFIX_ELECTRICITY_EQUIVALENT
+    ]
     if total_demand == 0:
         emissions_kWheleq = 0
     else:
         emissions_kWheleq = (
-            dict_values[KPI][KPI_SCALARS_DICT][TOTAL_EMISSIONS]
-            / total_demand
+            dict_values[KPI][KPI_SCALARS_DICT][TOTAL_EMISSIONS] / total_demand
         )
     dict_values[KPI][KPI_SCALARS_DICT].update(
         {SPECIFIC_EMISSIONS_ELEQ: emissions_kWheleq}

--- a/src/multi_vector_simulator/utils/constants.py
+++ b/src/multi_vector_simulator/utils/constants.py
@@ -239,6 +239,12 @@ KNOWN_EXTRA_PARAMETERS = {
         WARNING_TEXT: "allows setting a maximum capacity for an asset that is being capacity optimized (Values: None/Float). ",
         REQUIRED_IN_CSV_ELEMENTS: [ENERGY_CONVERSION, ENERGY_PRODUCTION],
     },
+    DSO_FEEDIN_CAP: {
+        DEFAULT_VALUE: None,
+        UNIT: TYPE_NONE,
+        WARNING_TEXT: "allows setting a maximum capacity for DSO feedin (Values: None/Float). ",
+        REQUIRED_IN_CSV_ELEMENTS: [ENERGY_PROVIDERS],
+    },
     RENEWABLE_ASSET_BOOL: {
         DEFAULT_VALUE: False,
         UNIT: TYPE_BOOL,

--- a/src/multi_vector_simulator/utils/constants_json_strings.py
+++ b/src/multi_vector_simulator/utils/constants_json_strings.py
@@ -191,6 +191,7 @@ CONNECTED_FEEDIN_SINK = "connected_feedin_sink"
 DISPATCHABILITY = "dispatchable"
 AVAILABILITY_DISPATCH = "availability_timeseries"
 ASSET_DICT = "asset_list"
+AUTO_CREATED_HIGHLIGHT = "(@)"
 #######################################
 # Parameters added in post-processing #
 #######################################

--- a/src/multi_vector_simulator/utils/constants_json_strings.py
+++ b/src/multi_vector_simulator/utils/constants_json_strings.py
@@ -179,6 +179,7 @@ INSTALLED_CAP_NORMALIZED = "installedCap_normalized"
 DSO_CONSUMPTION = "_consumption"
 DSO_FEEDIN = "_feedin"
 DSO_PEAK_DEMAND_SUFFIX = "_pdp"  # short for peak demand pricing
+DSO_FEEDIN_CAP = "feedin_cap"
 DSO_PEAK_DEMAND_PERIOD = "_period"
 CONNECTED_CONSUMPTION_SOURCE = "connected_consumption_sources"
 CONNECTED_PEAK_DEMAND_PRICING_TRANSFORMERS = (

--- a/src/multi_vector_simulator/utils/constants_json_strings.py
+++ b/src/multi_vector_simulator/utils/constants_json_strings.py
@@ -178,8 +178,8 @@ INSTALLED_CAP_NORMALIZED = "installedCap_normalized"
 # DSO
 DSO_CONSUMPTION = "_consumption"
 DSO_FEEDIN = "_feedin"
-DSO_PEAK_DEMAND_SUFFIX = "_pdp"  # short for peak demand pricing
 DSO_FEEDIN_CAP = "feedin_cap"
+DSO_PEAK_DEMAND_SUFFIX = "pdp"  # short for peak demand pricing
 DSO_PEAK_DEMAND_PERIOD = "_period"
 CONNECTED_CONSUMPTION_SOURCE = "connected_consumption_sources"
 CONNECTED_PEAK_DEMAND_PRICING_TRANSFORMERS = (

--- a/src/multi_vector_simulator/utils/helpers.py
+++ b/src/multi_vector_simulator/utils/helpers.py
@@ -10,6 +10,11 @@ Including:
 
 import os
 
+from multi_vector_simulator.utils.constants_json_strings import (
+    DSO_FEEDIN_CAP,
+    AUTO_CREATED_HIGHLIGHT,
+)
+
 
 def find_value_by_key(data, target, result=None):
     """
@@ -98,3 +103,8 @@ def get_length_if_list(list_or_float):
     else:
         answer = 0
     return answer
+
+
+def feedin_cap_bus_name(dso_name):
+    """Name for auto created bus related to feedin cap of DSO"""
+    return f"{dso_name}_{DSO_FEEDIN_CAP} {AUTO_CREATED_HIGHLIGHT}"

--- a/src/multi_vector_simulator/utils/helpers.py
+++ b/src/multi_vector_simulator/utils/helpers.py
@@ -13,6 +13,9 @@ import os
 from multi_vector_simulator.utils.constants_json_strings import (
     DSO_FEEDIN_CAP,
     AUTO_CREATED_HIGHLIGHT,
+    DSO_CONSUMPTION,
+    DSO_FEEDIN,
+    DSO_PEAK_DEMAND_PERIOD,
     DSO_PEAK_DEMAND_SUFFIX,
 )
 
@@ -106,11 +109,29 @@ def get_length_if_list(list_or_float):
     return answer
 
 
-def feedin_cap_bus_name(dso_name):
-    """Name for auto created bus related to feedin cap of DSO"""
-    return f"{dso_name}_{DSO_FEEDIN_CAP} {AUTO_CREATED_HIGHLIGHT}"
-
-
-def peak_demand_bus_name(dso_name):
+def peak_demand_bus_name(dso_name: str, feedin: bool = False):
     """Name for auto created bus related to peak demand pricing period"""
-    return f"{dso_name}_{DSO_PEAK_DEMAND_SUFFIX} {AUTO_CREATED_HIGHLIGHT}"
+
+    if feedin is False:
+        dso_direction = DSO_CONSUMPTION
+    else:
+        dso_direction = DSO_FEEDIN
+
+    return (
+        f"{dso_name}{dso_direction}_{DSO_PEAK_DEMAND_SUFFIX} {AUTO_CREATED_HIGHLIGHT}"
+    )
+
+
+def peak_demand_transformer_name(
+    dso_name: str, peak_number: int = None, feedin: bool = False
+):
+    """Name for auto created bus related to peak demand pricing period"""
+    if feedin is False:
+        dso_direction = DSO_CONSUMPTION
+    else:
+        dso_direction = DSO_FEEDIN
+    transformer_name = f"{dso_name}{dso_direction}{DSO_PEAK_DEMAND_PERIOD}"
+    if peak_number is not None:
+        transformer_name = f"{transformer_name}_{str(peak_number)}"
+
+    return f"{transformer_name} {AUTO_CREATED_HIGHLIGHT}"

--- a/src/multi_vector_simulator/utils/helpers.py
+++ b/src/multi_vector_simulator/utils/helpers.py
@@ -13,6 +13,7 @@ import os
 from multi_vector_simulator.utils.constants_json_strings import (
     DSO_FEEDIN_CAP,
     AUTO_CREATED_HIGHLIGHT,
+    DSO_PEAK_DEMAND_SUFFIX,
 )
 
 
@@ -108,3 +109,8 @@ def get_length_if_list(list_or_float):
 def feedin_cap_bus_name(dso_name):
     """Name for auto created bus related to feedin cap of DSO"""
     return f"{dso_name}_{DSO_FEEDIN_CAP} {AUTO_CREATED_HIGHLIGHT}"
+
+
+def peak_demand_bus_name(dso_name):
+    """Name for auto created bus related to peak demand pricing period"""
+    return f"{dso_name}_{DSO_PEAK_DEMAND_SUFFIX} {AUTO_CREATED_HIGHLIGHT}"

--- a/tests/test_C0_data_processing.py
+++ b/tests/test_C0_data_processing.py
@@ -76,6 +76,7 @@ from multi_vector_simulator.utils.constants_json_strings import (
     DSO_PEAK_DEMAND_SUFFIX,
     ENERGY_PRICE,
     DSO_FEEDIN,
+    AUTO_CREATED_HIGHLIGHT,
     CONNECTED_CONSUMPTION_SOURCE,
     CONNECTED_PEAK_DEMAND_PRICING_TRANSFORMERS,
     CONNECTED_FEEDIN_SINK,
@@ -224,7 +225,9 @@ def test_define_transformer_for_peak_demand_pricing():
     }
     dict_test_dso = dict_test[ENERGY_PROVIDERS]["dso"].copy()
     transformer_consumption_name = f"a_name_{DSO_CONSUMPTION}"
-    transformer_feedin_name = transformer_consumption_name.replace(DSO_CONSUMPTION, DSO_FEEDIN)
+    transformer_feedin_name = transformer_consumption_name.replace(
+        DSO_CONSUMPTION, DSO_FEEDIN
+    )
     timeseries_availability = pd.Series()
     C0.define_transformer_for_peak_demand_pricing(
         dict_test, dict_test_dso, transformer_consumption_name, timeseries_availability
@@ -775,6 +778,8 @@ def test_add_a_transformer_for_each_peak_demand_pricing_period_1_period():
         dict_test_trafo[ENERGY_PROVIDERS][DSO][LABEL]
         + DSO_CONSUMPTION
         + DSO_PEAK_DEMAND_PERIOD
+        + " "
+        + AUTO_CREATED_HIGHLIGHT
     ]
     assert (
         list_of_dso_energyConversion_assets == exp_list
@@ -801,12 +806,16 @@ def test_add_a_transformer_for_each_peak_demand_pricing_period_2_periods():
         + DSO_CONSUMPTION
         + DSO_PEAK_DEMAND_PERIOD
         + "_"
-        + str(1),
+        + str(1)
+        + " "
+        + AUTO_CREATED_HIGHLIGHT,
         dict_test[ENERGY_PROVIDERS][DSO][LABEL]
         + DSO_CONSUMPTION
         + DSO_PEAK_DEMAND_PERIOD
         + "_"
-        + str(2),
+        + str(2)
+        + " "
+        + AUTO_CREATED_HIGHLIGHT,
     ]
     assert (
         list_of_dso_energyConversion_assets == exp_list

--- a/tests/test_C0_data_processing.py
+++ b/tests/test_C0_data_processing.py
@@ -223,34 +223,36 @@ def test_define_transformer_for_peak_demand_pricing():
         },
     }
     dict_test_dso = dict_test[ENERGY_PROVIDERS]["dso"].copy()
-    transformer_name = "a_name"
+    transformer_consumption_name = f"a_name_{DSO_CONSUMPTION}"
+    transformer_feedin_name = transformer_consumption_name.replace(DSO_CONSUMPTION, DSO_FEEDIN)
     timeseries_availability = pd.Series()
     C0.define_transformer_for_peak_demand_pricing(
-        dict_test, dict_test_dso, transformer_name, timeseries_availability
+        dict_test, dict_test_dso, transformer_consumption_name, timeseries_availability
     )
-    assert transformer_name in dict_test[ENERGY_CONVERSION]
-    for k in [
-        LABEL,
-        OPTIMIZE_CAP,
-        INSTALLED_CAP,
-        INFLOW_DIRECTION,
-        OUTFLOW_DIRECTION,
-        AVAILABILITY_DISPATCH,
-        DISPATCH_PRICE,
-        SPECIFIC_COSTS,
-        DEVELOPMENT_COSTS,
-        SPECIFIC_COSTS_OM,
-        OEMOF_ASSET_TYPE,
-        EFFICIENCY,
-        ENERGY_VECTOR,
-    ]:
+    for transformer in (transformer_consumption_name, transformer_feedin_name):
+        assert transformer in dict_test[ENERGY_CONVERSION]
+        for k in [
+            LABEL,
+            OPTIMIZE_CAP,
+            INSTALLED_CAP,
+            INFLOW_DIRECTION,
+            OUTFLOW_DIRECTION,
+            AVAILABILITY_DISPATCH,
+            DISPATCH_PRICE,
+            SPECIFIC_COSTS,
+            DEVELOPMENT_COSTS,
+            SPECIFIC_COSTS_OM,
+            OEMOF_ASSET_TYPE,
+            EFFICIENCY,
+            ENERGY_VECTOR,
+        ]:
+            assert (
+                k in dict_test[ENERGY_CONVERSION][transformer]
+            ), f"Function does not add {k} to the asset dictionary of the {transformer}."
         assert (
-            k in dict_test[ENERGY_CONVERSION][transformer_name]
-        ), f"Function does not add {k} to the asset dictionary of the {transformer_name}."
-    assert (
-        dict_test[ENERGY_CONVERSION][transformer_name][SPECIFIC_COSTS_OM][VALUE]
-        == dict_test[ENERGY_PROVIDERS]["dso"][PEAK_DEMAND_PRICING][VALUE]
-    ), f"The {SPECIFIC_COSTS_OM} of the newly defined {transformer_name} is not equal to the {PEAK_DEMAND_PRICING} of the energy provider it is defined from."
+            dict_test[ENERGY_CONVERSION][transformer][SPECIFIC_COSTS_OM][VALUE]
+            == dict_test[ENERGY_PROVIDERS]["dso"][PEAK_DEMAND_PRICING][VALUE] / 2
+        ), f"The {SPECIFIC_COSTS_OM} of the newly defined {transformer} is not equal to half the {PEAK_DEMAND_PRICING} of the energy provider it is defined from."
 
 
 def test_define_energy_vectors_from_busses():

--- a/tests/test_C1_verification.py
+++ b/tests/test_C1_verification.py
@@ -45,7 +45,6 @@ from multi_vector_simulator.utils.constants_json_strings import (
     RENEWABLE_SHARE_DSO,
     ENERGY_BUSSES,
     ASSET_DICT,
-    DSO_PEAK_DEMAND_SUFFIX,
 )
 
 from multi_vector_simulator.utils.exceptions import (
@@ -53,6 +52,8 @@ from multi_vector_simulator.utils.exceptions import (
     DuplicateLabels,
     MVSOemofError,
 )
+
+from multi_vector_simulator.utils.helpers import peak_demand_bus_name
 
 
 def test_lookup_file_existing_file():
@@ -749,8 +750,7 @@ def test_check_for_sufficient_assets_on_busses_example_bus_fails(caplog):
 def test_check_for_sufficient_assets_on_busses_skipped_for_peak_demand_pricing_bus():
     dict_values = {
         ENERGY_BUSSES: {
-            "Bus"
-            + DSO_PEAK_DEMAND_SUFFIX: {
+            peak_demand_bus_name("Bus"): {
                 ASSET_DICT: {"asset_1": "asset_1", "asset_3": "asset_3"}
             }
         }

--- a/tests/test_benchmark_feedin.py
+++ b/tests/test_benchmark_feedin.py
@@ -126,18 +126,19 @@ class TestFeedinTariff:
             total_excess_scalar == 0
         ), f"When the feed-in tariff is positive there should be no electricity excess, however the scalar matrix shows an excess of {total_excess_scalar}"
 
+        dso_name = "DSO"
         # costs of DSO feed-in sink in scalars.xlsx should be negative, while they
         # should be substracted from the summed-up costs of the whole system
         # negative costs in cost_matrix:
         assert (
-            cost_matrix[COST_TOTAL][FEEDIN] < 0
-            and cost_matrix[COST_OPERATIONAL_TOTAL][FEEDIN] < 0
-            and cost_matrix[COST_DISPATCH][FEEDIN] < 0
-            and cost_matrix[LCOE_ASSET][FEEDIN] < 0
+            cost_matrix[COST_TOTAL][dso_name + DSO_FEEDIN] < 0
+            and cost_matrix[COST_OPERATIONAL_TOTAL][dso_name + DSO_FEEDIN] < 0
+            and cost_matrix[COST_DISPATCH][dso_name + DSO_FEEDIN] < 0
+            and cost_matrix[LCOE_ASSET][dso_name + DSO_FEEDIN] < 0
         ), f"When the feed-in tariff is positive the costs of the feed-in should be negative (scalar_matrix: {COST_TOTAL}, {COST_OPERATIONAL_TOTAL}, {COST_DISPATCH}, {LCOE_ASSET})."
         # costs substracted from total costs:
-        total_costs_feedin = cost_matrix[COST_TOTAL][FEEDIN]
-        total_costs_consumption = cost_matrix[COST_TOTAL][CONSUMPTION]
+        total_costs_feedin = cost_matrix[COST_TOTAL][dso_name + DSO_FEEDIN]
+        total_costs_consumption = cost_matrix[COST_TOTAL][dso_name + DSO_CONSUMPTION]
         total_costs_all_assets = scalars.loc[COST_TOTAL][0]
         assert (
             total_costs_all_assets == total_costs_feedin + total_costs_consumption
@@ -160,7 +161,8 @@ class TestFeedinTariff:
             TEST_INPUT_PATH, use_case, CSV_ELEMENTS, f"{ENERGY_PROVIDERS}.csv"
         )
         df = pd.read_csv(filename).set_index("Unnamed: 0")
-        df["DSO"][FEEDIN_TARIFF] = -float(df["DSO"][FEEDIN_TARIFF])
+        dso_name = df.columns[1]
+        df[dso_name][FEEDIN_TARIFF] = -float(df[dso_name][FEEDIN_TARIFF])
         df.to_csv(filename)
 
         main(
@@ -174,7 +176,7 @@ class TestFeedinTariff:
         )
 
         # reset feed-in tariff just in case
-        df["DSO"][FEEDIN_TARIFF] = -float(df["DSO"][FEEDIN_TARIFF])
+        df[dso_name][FEEDIN_TARIFF] = -float(df[dso_name][FEEDIN_TARIFF])
         df.to_csv(filename)
 
         df_busses_flow, cost_matrix, scalar_matrix, scalars = self.get_results(
@@ -252,7 +254,8 @@ class TestFeedinTariff:
             TEST_INPUT_PATH, use_case, CSV_ELEMENTS, f"{ENERGY_PROVIDERS}.csv"
         )
         df = pd.read_csv(filename).set_index("Unnamed: 0")
-        df["DSO"][FEEDIN_TARIFF] = -float(df["DSO"][FEEDIN_TARIFF])
+        dso_name = df.columns[1]
+        df[dso_name][FEEDIN_TARIFF] = -float(df[dso_name][FEEDIN_TARIFF])
         df.to_csv(filename)
 
         main(
@@ -265,7 +268,7 @@ class TestFeedinTariff:
             ),
         )
         # reset feed-in tariff just in case
-        df["DSO"][FEEDIN_TARIFF] = -float(df["DSO"][FEEDIN_TARIFF])
+        df[dso_name][FEEDIN_TARIFF] = -float(df[dso_name][FEEDIN_TARIFF])
         df.to_csv(filename)
 
         # get results

--- a/tests/test_benchmark_feedin.py
+++ b/tests/test_benchmark_feedin.py
@@ -24,10 +24,7 @@ from _constants import (
     BENCHMARK_TEST_INPUT_FOLDER,
 )
 
-from multi_vector_simulator.utils.constants import (
-    JSON_WITH_RESULTS,
-    JSON_FILE_EXTENSION,
-)
+from multi_vector_simulator.utils.helpers import peak_demand_transformer_name
 
 from multi_vector_simulator.utils.constants_json_strings import (
     DSO_CONSUMPTION,
@@ -55,8 +52,8 @@ from multi_vector_simulator.utils.constants_json_strings import (
 TEST_INPUT_PATH = os.path.join(TEST_REPO_PATH, BENCHMARK_TEST_INPUT_FOLDER)
 TEST_OUTPUT_PATH = os.path.join(TEST_REPO_PATH, BENCHMARK_TEST_OUTPUT_FOLDER)
 
-FEEDIN = f"DSO{DSO_FEEDIN}"
-CONSUMPTION = f"DSO{DSO_CONSUMPTION}"
+FEEDIN = peak_demand_transformer_name("DSO", feedin=True)
+CONSUMPTION = peak_demand_transformer_name("DSO")
 EXCESS_SINK_NAME = f"Electricity{EXCESS_SINK}"
 
 

--- a/tests/test_benchmark_scenarios.py
+++ b/tests/test_benchmark_scenarios.py
@@ -29,6 +29,8 @@ from _constants import (
     CSV_EXT,
 )
 
+from multi_vector_simulator.utils.helpers import peak_demand_transformer_name
+
 from multi_vector_simulator.utils.constants import (
     JSON_WITH_RESULTS,
     JSON_FILE_EXTENSION,
@@ -368,15 +370,10 @@ class TestACElectricityBus:
             flag_missing_values=False,
         )
         peak_demand = [
-            data[ENERGY_CONVERSION]["Electricity grid DSO_consumption_period_1"][
-                OPTIMIZED_ADD_CAP
-            ][VALUE],
-            data[ENERGY_CONVERSION]["Electricity grid DSO_consumption_period_2"][
-                OPTIMIZED_ADD_CAP
-            ][VALUE],
-            data[ENERGY_CONVERSION]["Electricity grid DSO_consumption_period_2"][
-                OPTIMIZED_ADD_CAP
-            ][VALUE],
+            data[ENERGY_CONVERSION][
+                peak_demand_transformer_name("Electricity grid DSO", peak_number=i)
+            ][OPTIMIZED_ADD_CAP][VALUE]
+            for i in (1, 2, 3)
         ]
         # read timeseries_all_busses excel file
         busses_flow = pd.read_excel(
@@ -387,9 +384,10 @@ class TestACElectricityBus:
         busses_flow = busses_flow.set_index("Unnamed: 0")
         # read the columns with the values to be used
         DSO_periods = [
-            busses_flow["Electricity grid DSO_consumption_period_1"],
-            busses_flow["Electricity grid DSO_consumption_period_2"],
-            busses_flow["Electricity grid DSO_consumption_period_3"],
+            busses_flow[
+                peak_demand_transformer_name("Electricity grid DSO", peak_number=i)
+            ]
+            for i in (1, 2, 3)
         ]
         demand = busses_flow["demand_01"]
         battery_charge = busses_flow[f"battery {INPUT_POWER}"]
@@ -467,7 +465,9 @@ class TestACElectricityBus:
                 / data[ENERGY_CONVERSION]["heat_pump"][EFFICIENCY][VALUE]
                 > data[ENERGY_PROVIDERS]["Heat_DSO"][ENERGY_PRICE][VALUE]
             ):
-                assert busses_flow["Heat_DSO_consumption_period"][i] == approx(
+                assert busses_flow[peak_demand_transformer_name("Heat_DSO")][
+                    i
+                ] == approx(
                     abs(busses_flow["demand_heat"][i])
                 ), f"Even though the marginal costs to use the heat pump are higher than the heat DSO price with {cost_of_using_heatpump} comp. {cost_of_using_heat_dso}, the heat DSO is not solely used for energy supply."
             else:


### PR DESCRIPTION
Prior to merge this PR #939  should be merged

Fix #941 

**Changes proposed in this pull request**:
- Add functions to format name of automatically created assets in DSO setting for feedin cap and peak demand pricing
- Enable feedin cap by adding a transformer and an extra bus between existing bus and DSO feedin
- Add a special character to name of busses created automatically

The following steps were realized, as well (if applies):
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [ ] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
