### PR TITLE
Do not replace all constraints by default values automatically if one constraint only is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Here is a template for new release sections
 - Update requirements for numpy (v 1.21.0 or greater) and for dash (v 2.3.1 or greater) (#938)
 - `OPTIMIZED_ADD_CAP` replaced by "optimized_add_cap" in the assets keys returned to EPA after simulating (#939)
 - The if statement for adapting `MAXIMUM_CAP` for non-dispatchable production assets is now based on the value of `DISPATCHABILITY` and not on the existence of the key `FILENAME` in the `asset_dict` (#939)
+- The default values for the constraints are now located in `src/constants.py` under the variable `DEFAULT_CONSTRAINT_VALUES` (#953)
 
 ### Removed
 - Input timeseries is now not returned to epa in `utils.data_parser.py` (#936)
@@ -62,6 +63,7 @@ Here is a template for new release sections
 - Used `pandas.concat` instead of `DataFrame.append` to add rows to a `pandas.DataFrame` instance to suppress UserWarning (#937)
 - Add missing file for test `test_F0_output.TestLogCreation.test_parse_simulation_log` (#937)
 - Transformers can have multiple input or output busses (tested in `tests/test_D1_model_components` by `test_transformer_optimize_cap_multiple_output_busses_multiple_inst_cap`, `test_transformer_optimize_cap_multiple_output_busses_multiple_max_add_cap`, `test_transformer_fix_cap_multiple_output_busses_multiple_inst_cap` and in `tests/test_benchmark_special_features` by `test_benchmark_feature_parameters_as_timeseries_multiple_inputs`)(#949)
+- The constraints are not all set to default values if only one constraint is missing, only the missing constraint is set to default value (#953)
 
 ## [1.0.0] - 2021-05-31
 

--- a/src/multi_vector_simulator/utils/constants.py
+++ b/src/multi_vector_simulator/utils/constants.py
@@ -199,6 +199,14 @@ REQUIRED_MVS_PARAMETERS = {
 MISSING_PARAMETERS_KEY = "missing_parameters"
 EXTRA_PARAMETERS_KEY = "extra_parameters"
 
+DEFAULT_CONSTRAINT_VALUES = {
+    MINIMAL_RENEWABLE_FACTOR: {UNIT: "factor", VALUE: 0},
+    MAXIMUM_EMISSIONS: {UNIT: "factor", VALUE: None},
+    MINIMAL_DEGREE_OF_AUTONOMY: {UNIT: "factor", VALUE: 0},
+    NET_ZERO_ENERGY: {UNIT: "bool", VALUE: False},
+}
+
+
 # Instroducting new parameters (later to be merged into list ll.77)
 WARNING_TEXT = "warning_text"
 REQUIRED_IN_CSV_ELEMENTS = "required in files"
@@ -250,13 +258,13 @@ KNOWN_EXTRA_PARAMETERS = {
         REQUIRED_IN_CSV_ELEMENTS: [ENERGY_PRODUCTION, ENERGY_PROVIDERS,],
     },
     MAXIMUM_EMISSIONS: {
-        DEFAULT_VALUE: None,
+        DEFAULT_VALUE: DEFAULT_CONSTRAINT_VALUES[MAXIMUM_EMISSIONS][VALUE],
         UNIT: TYPE_NONE,
         WARNING_TEXT: "allows setting a maximum amount of emissions of the optimized energy system (Values: None/Float). ",
         REQUIRED_IN_CSV_ELEMENTS: [CONSTRAINTS,],
     },
     MINIMAL_DEGREE_OF_AUTONOMY: {
-        DEFAULT_VALUE: 0,
+        DEFAULT_VALUE: DEFAULT_CONSTRAINT_VALUES[MINIMAL_DEGREE_OF_AUTONOMY][VALUE],
         UNIT: TYPE_FLOAT,
         WARNING_TEXT: "allows setting a minimum degree of autonomy of the optimized energy system (Values: Float). ",
         REQUIRED_IN_CSV_ELEMENTS: [CONSTRAINTS,],
@@ -268,7 +276,7 @@ KNOWN_EXTRA_PARAMETERS = {
         REQUIRED_IN_CSV_ELEMENTS: [PROJECT_DATA],
     },
     NET_ZERO_ENERGY: {
-        DEFAULT_VALUE: False,
+        DEFAULT_VALUE: DEFAULT_CONSTRAINT_VALUES[NET_ZERO_ENERGY][VALUE],
         UNIT: TYPE_BOOL,
         WARNING_TEXT: "allows to add a net zero energy constraint to optimization problem (activate by setting to `True`). ",
         REQUIRED_IN_CSV_ELEMENTS: [CONSTRAINTS,],

--- a/src/multi_vector_simulator/utils/data_parser.py
+++ b/src/multi_vector_simulator/utils/data_parser.py
@@ -25,6 +25,7 @@ from multi_vector_simulator.utils.constants import (
     TYPE_NONE,
     TYPE_BOOL,
     KNOWN_EXTRA_PARAMETERS,
+    DEFAULT_CONSTRAINT_VALUES,
     DEFAULT_VALUE,
 )
 
@@ -517,14 +518,16 @@ def convert_epa_params_to_mvs(epa_dict):
         error_msg = []
 
         missing_params = comparison[MISSING_PARAMETERS_KEY]
-        # this should not be missing on EPA side, but in case it is take default value 0
         if CONSTRAINTS in missing_params:
-            dict_values[CONSTRAINTS] = {
-                MINIMAL_RENEWABLE_FACTOR: {UNIT: "factor", VALUE: 0},
-                MAXIMUM_EMISSIONS: {UNIT: "factor", VALUE: None},
-                MINIMAL_DEGREE_OF_AUTONOMY: {UNIT: "factor", VALUE: 0},
-                NET_ZERO_ENERGY: {UNIT: "bool", VALUE: False},
-            }
+
+            if CONSTRAINTS not in dict_values:
+                dict_values[CONSTRAINTS] = {}
+
+            for missing_constraint in missing_params[CONSTRAINTS]:
+                dict_values[CONSTRAINTS][
+                    missing_constraint
+                ] = DEFAULT_CONSTRAINT_VALUES[missing_constraint]
+
             missing_params.pop(CONSTRAINTS)
 
         if SIMULATION_SETTINGS in missing_params:


### PR DESCRIPTION
Fix [161](https://github.com/open-plan-tool/gui/issues/161)

**Changes proposed in this pull request**:
- The constraints are not all set to default values if only one constraint is missing, only the missing constraint is set to default value
- The default values for the constraints are now located in `src/constants.py` under the variable `DEFAULT_CONSTRAINT_VALUES`

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
