### PR TITLE
Fix a bug in replacement cost calculation reinvest in project last year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ Here is a template for new release sections
 - Transformers can have multiple input or output busses (tested in `tests/test_D1_model_components` by `test_transformer_optimize_cap_multiple_output_busses_multiple_inst_cap`, `test_transformer_optimize_cap_multiple_output_busses_multiple_max_add_cap`, `test_transformer_fix_cap_multiple_output_busses_multiple_inst_cap` and in `tests/test_benchmark_special_features` by `test_benchmark_feature_parameters_as_timeseries_multiple_inputs`)(#949)
 - The constraints are not all set to default values if only one constraint is missing, only the missing constraint is set to default value (#953)
 - If the age of an asset is such that it should be replaced on the project's last year, we do not take it into account as the resell price would be deduced anyway (#965)
+- The test `test_c2_economic_functions.py::test_get_replacement_costs_one_reinvestment_age_asset_equal_asset_lifetime` was added to account for a field usecase and a solution was provided (#966)
+
 
 ## [1.0.0] - 2021-05-31
 

--- a/tests/test_C2_economic_functions.py
+++ b/tests/test_C2_economic_functions.py
@@ -185,6 +185,18 @@ def test_get_replacement_costs_no_reinvestment_residual():
     assert replacement_costs == exp
 
 
+def test_get_replacement_costs_one_reinvestment_age_asset_equal_asset_lifetime():
+    replacement_costs = C2.get_replacement_costs(
+        age_of_asset=10,
+        project_lifetime=20,
+        asset_lifetime=10,
+        first_time_investment=550,
+        discount_factor=0.1,
+    )
+    exp = 762.0488091862422
+    assert replacement_costs == exp
+
+
 def test_present_value_from_annuity():
     """
 


### PR DESCRIPTION
**Changes proposed in this pull request**:
- The test `test_c2_economic_functions.py::test_get_replacement_costs_one_reinvestment_age_asset_equal_asset_lifetime` was added to account for a field usecase and a solution was provided

The following steps were realized, as well (if applies):
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code ([example docstring](https://multi-vector-simulator.readthedocs.io/en/latest/Developing.html#format-of-docstrings))
- [ ] For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code (pytests, assertion debug messages)
- [x] Update the CHANGELOG.md
- [x] Apply black (`black . --exclude docs/`)
- [x] Check if benchmark tests pass locally (`EXECUTE_TESTS_ON=master pytest`)


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done

:x: Check not applicable to this PR

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl-institut/multi-vector-simulator/blob/dev/CONTRIBUTING.md).*<sub>
