### PR TITLE
Add mandatory build-os parameter to RTD config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,6 +3,13 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 # Required
 version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -12,7 +19,6 @@ sphinx:
 #  configuration: mkdocs.yml
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.7
    install:
       - requirements: requirements/docs.txt
       - requirements: requirements/default.txt


### PR DESCRIPTION
Our previous settings are deprecated since September 25th 2023 https://blog.readthedocs.com/migrate-configuration-v2/

Fix readthedocs build
